### PR TITLE
feat(portfolio): 넥슨 2026 프론트엔드 챕터 페이지 추가

### DIFF
--- a/dashboard/frontend/src/App.tsx
+++ b/dashboard/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, useLocation } from 'react-router-dom'
+import { Routes, Route, useLocation, Navigate } from 'react-router-dom'
 import { useEffect } from 'react'
 import { AuthProvider } from './contexts/AuthContext'
 import { ThemeProvider } from './contexts/ThemeContext'
@@ -32,6 +32,8 @@ import PortfolioNimbleNeuronPrint from './pages/PortfolioNimbleNeuronPrint'
 import PortfolioSmilegate from './pages/PortfolioSmilegate'
 import PortfolioSmilegateCompare from './pages/PortfolioSmilegateCompare'
 import PageLLM from './pages/PortfolioNexon2026/PageLLM'
+import PageFrontend from './pages/PortfolioNexon2026/PageFrontend'
+import PageFrontendDeck from './pages/PortfolioNexon2026/PageFrontendDeck'
 import PageService from './pages/PortfolioNexon2026/PageService'
 import PageQA from './pages/PortfolioNexon2026/PageQA'
 import PageMotionCatalog from './pages/PortfolioNexon2026/PageMotionCatalog'
@@ -123,7 +125,9 @@ function App() {
           <Route path="/portfolio/nimble-neuron/print" element={<PortfolioNimbleNeuronPrint />} />
           <Route path="/portfolio/smilegate" element={<PortfolioSmilegate />} />
           <Route path="/portfolio/smilegate-compare" element={<PortfolioSmilegateCompare />} />
-          <Route path="/portfolio/nexon" element={<PageLLM />} />
+          <Route path="/portfolio/nexon" element={<Navigate to="/portfolio/nexon/frontend" replace />} />
+          <Route path="/portfolio/nexon/frontend" element={<PageFrontendDeck />} />
+          <Route path="/portfolio/nexon/frontend-scroll" element={<PageFrontend />} />
           <Route path="/portfolio/nexon/llm" element={<PageLLM />} />
           <Route path="/portfolio/nexon/service" element={<PageService />} />
           <Route path="/portfolio/nexon/qa" element={<PageQA />} />

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/PageFrontend.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/PageFrontend.tsx
@@ -1,0 +1,147 @@
+/**
+ * [AI본부 메이플AX실] 웹 프론트엔드 엔지니어 (인턴) — 넥슨코리아
+ * 라우트: /portfolio/nexon/frontend-scroll (스크롤형 보존본 · 대표는 PageFrontendDeck)
+ * 공고: careers.nexon.com/recruit/10027
+ *
+ * 페이지 구조 — PageLLM 엔진 재사용, 콘텐츠만 웹FE (FE 접미사 파일)
+ *   NexonGateFE (Hero/로딩 게이트)
+ *   Ch1AboutFE  — 01 ABOUT, 02 DETAILS
+ *   Ch2WhatFE   — 02 ARCHITECTURE, 03 STACK
+ *   Ch3WhyFE    — 04 JD, 05 ELIGIBILITY, 06 GAMES, 07 CASES
+ *   Ch4ReachFE  — CTA + Footer
+ */
+
+import { useEffect, useRef } from 'react'
+import Lenis from 'lenis'
+import { trackEvent } from '../../lib/analytics'
+import gsap from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+import { C, FONT_BODY } from './shared/colors'
+import SideNav from './shared/SideNav'
+import CornerLabels from './shared/CornerLabels'
+import MapleChatbot from './shared/MapleChatbot'
+import NexonGate from './shared/NexonGateFE'
+import { useRevealOff } from './shared/useRevealOff'
+import { CharacterDockProvider } from './shared/dockContext'
+
+import Ch1About from './sections/Ch1AboutFE'
+import Ch2What from './sections/Ch2WhatFE'
+import Ch3Why from './sections/Ch3WhyFE'
+import Ch4Reach from './sections/Ch4ReachFE'
+
+// 챕터별 진입 1회 발사. IntersectionObserver 25% 임계, fired flag 로 dedup.
+function ChapterTrack({ chapter, children }: { chapter: string; children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const fired = useRef(false)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const e of entries) {
+          if (e.isIntersecting && !fired.current) {
+            fired.current = true
+            trackEvent('portfolio_chapter_view', { chapter })
+            io.disconnect()
+          }
+        }
+      },
+      // viewport 위/아래 25% 를 잘라낸 가운데 50% 영역에 target 의 어떤 부분이라도
+      // 들어오면 fire. 챕터 높이가 viewport 보다 큰 경우에도 안전하게 트리거됨.
+      { threshold: 0, rootMargin: '-25% 0px -25% 0px' },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [chapter])
+  return <div ref={ref}>{children}</div>
+}
+
+export default function PageFrontend() {
+  const revealOff = useRevealOff()
+
+  // Lenis smooth scroll + GSAP ticker 연동
+  useEffect(() => {
+    gsap.registerPlugin(ScrollTrigger)
+
+    const lenis = new Lenis({
+      // 쫀득한 스크롤 — 휠 입력 후 잠시 미끄러지듯 따라옴
+      duration: 1.2,
+      // lerp 가 작을수록 더 부드럽고 길게 미끄러짐 (default 0.1)
+      lerp: 0.8,
+      wheelMultiplier: 2.0,
+      easing: (t: number) => Math.min(1, 1.001 - Math.pow(2, -10 * t)),
+    })
+    ;(window as any).__lenis = lenis
+    lenis.scrollTo(0, { immediate: true })
+
+    lenis.on('scroll', ScrollTrigger.update)
+    const tickerCb = (time: number) => lenis.raf(time * 1000)
+    gsap.ticker.add(tickerCb)
+    gsap.ticker.lagSmoothing(0)
+
+    return () => {
+      gsap.ticker.remove(tickerCb)
+      ScrollTrigger.getAll().forEach((st) => st.kill())
+      lenis.destroy()
+      ;(window as any).__lenis = null
+    }
+  }, [])
+
+  return (
+    <CharacterDockProvider>
+    <div
+      data-reveal-off={revealOff ? 'true' : undefined}
+      style={{
+        fontFamily: FONT_BODY,
+        color: C.ink,
+        letterSpacing: '-0.01em',
+        background: C.bgLight,
+        minHeight: '100vh',
+        overflowX: 'clip',
+      }}
+    >
+      {revealOff && (
+        <style>{`
+          /* ?reveal=off — Figma html-to-design / 정적 캡처용 일괄 visible */
+          [data-reveal-off="true"] *,
+          [data-reveal-off="true"] *::before,
+          [data-reveal-off="true"] *::after {
+            opacity: 1 !important;
+            filter: none !important;
+            visibility: visible !important;
+            clip-path: none !important;
+          }
+          [data-reveal-off="true"] .word,
+          [data-reveal-off="true"] .word-piece {
+            opacity: 1 !important;
+            filter: none !important;
+            transform: none !important;
+          }
+        `}</style>
+      )}
+
+      <CornerLabels label="NEXON · WEB FE" ctaLabel="GO TO BOT" ctaHref="https://debimarlene.com" />
+      <MapleChatbot intro="안녕하세요, 디지털 클론 양건호입니다. 롯데월드 메이플 콜라보 때 전광판 타워에서 QR로 소환됐던 캐릭터처럼, 이 페이지를 스크롤 따라 돌아다녀요. 프론트엔드나 kasaterm, 뭐든 물어보세요." />
+
+      <SideNav
+        sections={[
+          { id: 'hero', no: 'CH 0', label: 'GATE' },
+          { id: 'about', no: 'CH 1', label: 'WHO' },
+          { id: 'architecture', no: 'CH 2', label: 'WHAT' },
+          { id: 'jdmatch', no: 'CH 3·04', label: 'JD' },
+          { id: 'eligibility', no: 'CH 3·05', label: 'ELIG' },
+          { id: 'preferred', no: 'CH 3·06', label: 'GAMES' },
+          { id: 'troubleshooting', no: 'CH 3·07', label: 'CASES' },
+          { id: 'contact', no: 'CH 4', label: 'REACH' },
+        ]}
+      />
+
+      <NexonGate />
+      <ChapterTrack chapter="ch1_about"><Ch1About /></ChapterTrack>
+      <ChapterTrack chapter="ch2_what"><Ch2What /></ChapterTrack>
+      <ChapterTrack chapter="ch3_why"><Ch3Why /></ChapterTrack>
+      <ChapterTrack chapter="ch4_reach"><Ch4Reach /></ChapterTrack>
+    </div>
+    </CharacterDockProvider>
+  )
+}

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/PageFrontendDeck.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/PageFrontendDeck.tsx
@@ -1,0 +1,704 @@
+/**
+ * [AI본부 메이플AX실] 웹 프론트엔드 엔지니어 (인턴) — 넥슨코리아
+ * 라우트: /portfolio/nexon/frontend (대표 · 제출용)
+ * 공고: careers.nexon.com/recruit/10027
+ *
+ * 사이오닉 슬라이드덱 엔진(shared/SlideDeck) 재사용 + content/frontend 콘텐츠.
+ * 다크/라이트 토글(좌하단) · 우측 진행바 · 은은한 배경 · 가로 카드 스택.
+ * 구조: Hero → 선언 → About(+STACK 마퀴) → JD매칭 → Cases → 자격·우대 → Closing+Footer
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { motion, useScroll, useTransform, animate } from 'framer-motion'
+import Aurora from '../../components/common/Aurora'
+import BlurText from '../../components/common/BlurText'
+import Ballpit from '../../components/common/Ballpit'
+import TextType from '../../components/reactbits/TextType'
+import FloatingShapes from './shared/FloatingShapes'
+import SlideDeck, { type Slide } from './shared/SlideDeck'
+import MapleChatbot from './shared/MapleChatbot'
+import { HERO, STATS, ABOUT, JD_MATCHES, PREFERRED, ELIGIBILITY, CASES, CONTACT, ARCHITECTURE, GAMES } from './content/frontend'
+
+const FONT = "'Pretendard Variable', 'Pretendard', 'Paperlogy', -apple-system, BlinkMacSystemFont, sans-serif"
+const ACCENT = '#0091CC' // 넥슨 블루
+const BLUE_LIGHT = '#5BC0E5'
+const BAND = '#0A1326' // 마퀴·Footer 강조 밴드 (모드 무관 다크)
+
+// 넥슨 메이플AX실 공고 조직소개 인용 (About 슬라이드 blockquote)
+const NEXON_QUOTE =
+  '단순한 AI API 호출을 넘어, 브라우저에서 시각 요소를 자유롭게 편집하고 실시간으로 협업할 수 있는 리치 애플리케이션을 지향합니다.'
+
+const KEY_TRAITS = [
+  '디자이너 출신 프론트엔드', 'React · Vite · TypeScript', 'three.js · WebGL · wgpu', 'GSAP · Lenis 스크롤',
+  'Rust GPU 터미널(kasaterm)', '디자인 시스템 · 토큰', 'SSE 실시간 스트리밍', 'MCP · hook 하네스',
+]
+const STACK_A = ['React 19', 'Vite', 'TypeScript', 'Tailwind', 'GSAP', 'ScrollTrigger', 'Lenis', 'framer-motion', 'three.js', 'WebGL']
+const STACK_B = ['Rust', 'wgpu', 'winit', 'vt100', 'damage tracking', 'P3 / Bradford', 'Managed Agents', 'SSE', 'MCP · hook', 'LiteLLM', 'RAG']
+
+// 03 STACK 상세 — 카테고리별 헤드라인 + chips (스크롤 포폴 Ch2WhatFE 에서 이관)
+const STACK_DETAIL: { category: string; headline: string; chips: string[] }[] = [
+  { category: 'FRONTEND · 프레임워크', headline: 'React 19 + Vite + TypeScript + Tailwind — 이 페이지의 뼈대', chips: ['React 19', 'Vite', 'TypeScript', 'Tailwind'] },
+  { category: 'FRONTEND · 스크롤·모션', headline: 'GSAP ScrollTrigger + Lenis + framer-motion 을 한 루프로', chips: ['GSAP', 'ScrollTrigger', 'Lenis', 'framer-motion'] },
+  { category: 'FRONTEND · 3D·그래픽스', headline: 'three.js 배경 + WebGL 셰이더를 섹션별로 교체', chips: ['three.js', 'WebGL', 'Ballpit', 'Aurora'] },
+  { category: 'NATIVE · GPU 터미널', headline: 'kasaterm — Rust 로 직접 짠 GPU 셀 렌더러', chips: ['Rust', 'wgpu', 'winit', 'vt100'] },
+  { category: 'NATIVE · 렌더 최적화', headline: 'damage tracking + P3/Bradford 색 파이프라인 (1.25GB→113MB)', chips: ['damage tracking', 'P3', 'Bradford', 'GPU readback'] },
+  { category: 'AI · 모델 연동', headline: 'Anthropic Managed Agent SSE 스트리밍 챗봇 (이 페이지 하단)', chips: ['Managed Agents', 'SSE', 'streaming'] },
+  { category: 'AI · 개발 하네스', headline: 'MCP + hook + 서브에이전트 + LiteLLM 멀티모델 스위칭', chips: ['MCP', 'hook', '서브에이전트', 'LiteLLM'] },
+  { category: 'INFRA · 배포', headline: 'PWA + Cloudflare 캐시 + GCP · Docker', chips: ['PWA', 'Cloudflare', 'GCP', 'Docker'] },
+]
+
+// 슬라이드 index별 캐릭터 말풍선 — SlideDeck onIndexChange 로 char-say 이벤트 dispatch.
+// 스크롤이 없는 덱이라 캐릭터가 섹션 전환을 스크롤로 감지 못 함 → 여기서 직접 먹여준다.
+const SECTION_BUBBLES = [
+  '안녕하세요!\n디지털 클론 양건호예요 👋',
+  '디자인도 개발도\n제가 다 합니다 💪',
+  '제 소개, 읽어봐 주세요 📖',
+  '이 페이지, 어떻게\n만들었는지 볼까요? 🛠️',
+  '이 화면을 굴리는\n기술 스택이에요 ⚙️',
+  '넥슨 JD랑 어떻게\n맞물리는지 볼까요? 🎯',
+  '지원 자격, 저는\n이미 매일 씁니다 ✅',
+  '메이플 16년 차\n헤비 게이머예요 🍁',
+  '직접 해결한\n사례들이에요 🔧',
+  '끝까지 봐주셔서\n감사합니다 💙',
+]
+
+// ─────────────────────────────────────────────
+// 테마
+// ─────────────────────────────────────────────
+
+function makeTheme(isDark: boolean) {
+  return {
+    isDark,
+    pageBg: isDark ? '#070D1C' : '#F4F7FB',
+    sec: isDark ? '#0C1528' : '#FFFFFF',
+    secAlt: isDark ? '#080F20' : '#F4F7FB',
+    ink: isDark ? '#FFFFFF' : '#0A1224',
+    sub: isDark ? 'rgba(255,255,255,0.68)' : '#3F4A5F',
+    muted: isDark ? 'rgba(255,255,255,0.5)' : '#8A95A6',
+    card: isDark ? 'rgba(255,255,255,0.05)' : '#FFFFFF',
+    cardSolid: isDark ? '#0E1A33' : '#FFFFFF',
+    cardBorder: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(10,18,36,0.08)',
+    cardShadow: isDark ? '0 24px 60px -16px rgba(0,0,0,0.5)' : '0 24px 60px -16px rgba(10,18,36,0.16)',
+    accentSoft: isDark ? 'rgba(0,145,204,0.16)' : '#E6F5FB',
+    line: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(10,18,36,0.1)',
+  }
+}
+type Theme = ReturnType<typeof makeTheme>
+
+function ThemeToggle({ isDark, toggle }: { isDark: boolean; toggle: () => void }) {
+  return (
+    <button
+      onClick={toggle}
+      aria-label="다크/라이트 전환"
+      style={{
+        position: 'fixed', bottom: 24, left: 24, zIndex: 200, width: 50, height: 50, borderRadius: 9999,
+        border: `1px solid ${isDark ? 'rgba(255,255,255,0.22)' : 'rgba(10,18,36,0.12)'}`,
+        background: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.92)',
+        backdropFilter: 'blur(10px)', boxShadow: '0 8px 24px rgba(0,0,0,0.22)', cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: isDark ? '#FFD166' : '#0A1224', transition: 'all 200ms',
+      }}
+    >
+      {isDark ? (
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="5" /><line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" /><line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" /><line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" /><line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" /></svg>
+      ) : (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" /></svg>
+      )}
+    </button>
+  )
+}
+
+// ─────────────────────────────────────────────
+// CountUp / Marquee / 모션
+// ─────────────────────────────────────────────
+
+function CountUp({ value }: { value: string }) {
+  const target = parseInt(String(value).replace(/[^0-9]/g, ''), 10) || 0
+  const [disp, setDisp] = useState('0')
+  useEffect(() => {
+    const controls = animate(0, target, { duration: 1.4, delay: 0.35, ease: [0.22, 1, 0.36, 1], onUpdate: (v) => setDisp(Math.round(v).toLocaleString()) })
+    return () => controls.stop()
+  }, [target])
+  return <span>{disp}</span>
+}
+
+function Marquee({ items, reverse = false, duration = 28 }: { items: readonly string[]; reverse?: boolean; duration?: number }) {
+  const doubled = [...items, ...items]
+  return (
+    <div style={{ overflow: 'hidden', maskImage: 'linear-gradient(90deg, transparent, #000 7%, #000 93%, transparent)', WebkitMaskImage: 'linear-gradient(90deg, transparent, #000 7%, #000 93%, transparent)' }}>
+      <motion.div style={{ display: 'flex', gap: 14, width: 'max-content', paddingBlock: 6 }} animate={{ x: reverse ? ['-50%', '0%'] : ['0%', '-50%'] }} transition={{ duration, ease: 'linear', repeat: Infinity }}>
+        {doubled.map((it, i) => (
+          <span key={i} style={{ display: 'inline-flex', alignItems: 'center', gap: 9, padding: '11px 20px', borderRadius: 9999, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.12)', color: 'rgba(255,255,255,0.9)', fontFamily: FONT, fontSize: 14.5, fontWeight: 600, whiteSpace: 'nowrap', letterSpacing: '-0.005em' }}>
+            <span style={{ width: 6, height: 6, borderRadius: '50%', background: BLUE_LIGHT, flexShrink: 0 }} />
+            {it}
+          </span>
+        ))}
+      </motion.div>
+    </div>
+  )
+}
+
+function FadeIn({ children, delay = 0 }: { children: React.ReactNode; delay?: number }) {
+  return (
+    <motion.div initial={{ opacity: 0, y: 24 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true, amount: 0.05 }} transition={{ duration: 0.7, delay, ease: [0.22, 1, 0.36, 1] }}>
+      {children}
+    </motion.div>
+  )
+}
+
+// 슬라이드별 배경 이펙트 — variant 로 종류를 달리해 Aurora 도배를 피한다.
+// 인접 슬라이드끼리 같은 종류가 겹치지 않게 매핑(Shapes·Aurora·Ballpit).
+type BgVariant = 'aurora-blue' | 'aurora-violet' | 'shapes' | 'shapes-flip' | 'ballpit'
+function SectionBg({ t, variant = 'aurora-blue' }: { t: Theme; variant?: BgVariant }) {
+  if (variant === 'shapes' || variant === 'shapes-flip') {
+    return (
+      <div className="absolute inset-0 pointer-events-none" style={{ zIndex: 0, opacity: t.isDark ? 0.55 : 0.7, transform: variant === 'shapes-flip' ? 'scaleX(-1)' : undefined }}>
+        <FloatingShapes />
+      </div>
+    )
+  }
+  if (variant === 'ballpit') {
+    return (
+      <div className="absolute inset-0 pointer-events-none" style={{ zIndex: 0, opacity: t.isDark ? 0.9 : 0.72 }}>
+        <Ballpit colors={[0x0091cc, 0x5bc0e5, 0xbfe6f5]} count={110} gravity={0.4} friction={0.995} maxSize={1.1} minSize={0.4} followCursor />
+      </div>
+    )
+  }
+  const stops = variant === 'aurora-violet' ? ['#6D5EF7', '#00B4D8', '#48CAE4'] : [ACCENT, '#5BC0E5', '#BFE6F5']
+  return (
+    <div className="absolute inset-0 pointer-events-none" style={{ zIndex: 0, opacity: t.isDark ? 0.34 : 0.22 }}>
+      <Aurora colorStops={stops} amplitude={1.0} speed={0.35} />
+    </div>
+  )
+}
+
+function SectionHeader({ no, kicker, title, t }: { no: string; kicker: string; title: string; t: Theme }) {
+  return (
+    <FadeIn>
+      <div style={{ marginBottom: 56 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 16, marginBottom: 24 }}>
+          <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: ACCENT, letterSpacing: '0.18em' }}>{no}</span>
+          <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 600, color: t.muted, letterSpacing: '0.18em' }}>{kicker}</span>
+          <span style={{ flex: 1, height: 1, background: t.line }} />
+        </div>
+        <h2 style={{ fontFamily: FONT, fontSize: 'clamp(30px, 4.2vw, 50px)', fontWeight: 800, lineHeight: 1.2, letterSpacing: '-0.025em', color: t.ink, margin: 0, whiteSpace: 'pre-line', wordBreak: 'keep-all' }}>{title}</h2>
+      </div>
+    </FadeIn>
+  )
+}
+
+// 풀스크린 텍스트 슬라이드 — 큰 한 줄 + 부제 (BlurText 어절 등장)
+function Statement({ text, sub, kicker, bg, t, bgVariant = 'aurora-blue' }: { text: string; sub?: string; kicker: string; bg: string; t: Theme; bgVariant?: BgVariant }) {
+  return (
+    <section style={{ position: 'absolute', inset: 0, padding: 'clamp(48px, 6vw, 96px)', background: bg, overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+      <SectionBg t={t} variant={bgVariant} />
+      <div style={{ maxWidth: 1080, margin: '0 auto', width: '100%', position: 'relative', zIndex: 1 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(26px, 4.2vh, 48px)' }}>
+          <span style={{ width: 24, height: 1, background: ACCENT }} />
+          <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: ACCENT, letterSpacing: '0.24em' }}>{kicker}</span>
+        </div>
+        <div style={{ fontFamily: FONT, fontSize: 'clamp(28px, 4.6vw, 58px)', fontWeight: 800, lineHeight: 1.24, letterSpacing: '-0.035em', color: t.ink, wordBreak: 'keep-all' }}>
+          {text.split('\n').map((line, i) => (
+            <BlurText key={i} text={line} delay={55} animateBy="words" direction="bottom" className="!m-0" />
+          ))}
+        </div>
+        {sub && (
+          <p style={{ fontFamily: FONT, fontSize: 'clamp(15px, 1.7vw, 20px)', fontWeight: 500, lineHeight: 1.65, color: t.sub, margin: 'clamp(24px, 3.6vh, 44px) 0 0', maxWidth: 720, wordBreak: 'keep-all' }}>{sub}</p>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function Kicker({ label, no }: { label: string; no?: string }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 'clamp(20px, 3vh, 30px)' }}>
+      <span style={{ width: 24, height: 1, background: ACCENT }} />
+      {no && <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: ACCENT, letterSpacing: '0.18em' }}>{no}</span>}
+      <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: ACCENT, letterSpacing: '0.22em' }}>{label}</span>
+    </div>
+  )
+}
+
+// 섹션↔캐릭터 상호작용 칩 — 누르면 우하단 캐릭터(챗봇)가 열리며 이 질문을 자동 전송한다.
+function AskChip({ prompt, label, t }: { prompt: string; label?: string; t: Theme }) {
+  return (
+    <button
+      onClick={() => window.dispatchEvent(new CustomEvent('nexon:char-ask', { detail: { prompt } }))}
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 9, padding: '10px 16px', borderRadius: 9999, background: t.accentSoft, border: `1px solid ${ACCENT}44`, color: ACCENT, fontFamily: FONT, fontSize: 13, fontWeight: 700, letterSpacing: '-0.005em', cursor: 'pointer', transition: 'transform 180ms, box-shadow 180ms' }}
+      onMouseEnter={(e) => { e.currentTarget.style.transform = 'translateY(-2px)'; e.currentTarget.style.boxShadow = `0 8px 20px ${ACCENT}33` }}
+      onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; e.currentTarget.style.boxShadow = 'none' }}
+    >
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke={ACCENT} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" /></svg>
+      <span>{label ?? prompt}</span>
+      <span style={{ fontSize: 11, fontWeight: 800, opacity: 0.65 }}>· 물어보기</span>
+    </button>
+  )
+}
+
+function SlidePane({ children, bg, t, withBg = true, center = true, pad, bgVariant = 'aurora-blue' }: { children: React.ReactNode; bg: string; t: Theme; withBg?: boolean; center?: boolean; pad?: string; bgVariant?: BgVariant }) {
+  return (
+    <section style={{ position: 'absolute', inset: 0, background: bg, overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: center ? 'center' : 'flex-start', padding: pad ?? 'clamp(56px, 8vh, 104px) clamp(28px, 6vw, 96px)' }}>
+      {withBg && <SectionBg t={t} variant={bgVariant} />}
+      <div style={{ maxWidth: 1180, margin: '0 auto', width: '100%', position: 'relative', zIndex: 1 }}>{children}</div>
+    </section>
+  )
+}
+
+function PanelShell({ children }: { children: React.ReactNode }) {
+  return (
+    <section style={{ width: '100%', height: '100%', position: 'relative', overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: 'center', padding: 'clamp(56px, 8vh, 104px) clamp(40px, 7vw, 120px)' }}>
+      <div style={{ maxWidth: 1180, margin: '0 auto', width: '100%', position: 'relative', zIndex: 1 }}>{children}</div>
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────
+// Hero
+// ─────────────────────────────────────────────
+
+function Hero({ t }: { t: Theme }) {
+  const heroRef = useRef<HTMLElement>(null)
+  const { scrollYProgress } = useScroll({ target: heroRef, offset: ['start start', 'end start'] })
+  const textY = useTransform(scrollYProgress, [0, 1], ['0%', '18%'])
+  const heroBg = t.isDark
+    ? 'radial-gradient(125% 95% at 50% 0%, #0B1E42 0%, #070D20 55%, #04060F 100%)'
+    : 'radial-gradient(125% 95% at 50% 0%, #E4EEFF 0%, #F4F7FB 58%, #F4F7FB 100%)'
+
+  return (
+    <section ref={heroRef} style={{ position: 'absolute', inset: 0, padding: 'clamp(36px, 5vw, 56px) clamp(28px, 6vw, 48px)', overflow: 'hidden', background: heroBg, display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+      {/* 첫 화면 배경 = Ballpit(three.js). 커서를 따라 공이 밀린다 — 도입부 인터랙션. */}
+      <div className="absolute inset-0 pointer-events-none" style={{ zIndex: 0, opacity: t.isDark ? 0.9 : 0.62 }}>
+        <Ballpit colors={[0x0091cc, 0x5bc0e5, 0xbfe6f5]} count={90} gravity={0.32} friction={0.997} maxSize={1.0} minSize={0.4} followCursor />
+      </div>
+
+      <header style={{ position: 'relative', zIndex: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', maxWidth: 1180, margin: '0 auto', paddingBottom: 24, borderBottom: `1px solid ${t.line}`, color: t.isDark ? BLUE_LIGHT : ACCENT, flexWrap: 'wrap', gap: 16 }}>
+        <span style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.12em', opacity: 0.9, fontWeight: 700 }}>PORTFOLIO · {HERO.jobCode}</span>
+        <span style={{ fontFamily: FONT, fontSize: 11, letterSpacing: '0.08em', opacity: 0.9, fontWeight: 700 }}>YANG · GEONHO / 2026</span>
+      </header>
+
+      <motion.div style={{ y: textY, maxWidth: 1180, margin: '0 auto', position: 'relative', zIndex: 1, paddingTop: 88, paddingBottom: 56 }}>
+        <FadeIn delay={0}>
+          <div style={{ display: 'inline-flex', alignItems: 'center', gap: 10, marginBottom: 36, fontFamily: FONT, fontSize: 12.5, fontWeight: 700, color: t.isDark ? BLUE_LIGHT : ACCENT, letterSpacing: '0.03em' }}>
+            <span style={{ width: 7, height: 7, borderRadius: '50%', background: ACCENT, boxShadow: `0 0 0 4px ${ACCENT}28` }} />
+            {HERO.badge}
+          </div>
+        </FadeIn>
+
+        <FadeIn delay={0.15}>
+          <div style={{ fontFamily: FONT, fontSize: 'clamp(40px, 7vw, 84px)', fontWeight: 900, lineHeight: 1.1, letterSpacing: '-0.04em', color: t.ink, wordBreak: 'keep-all', textShadow: t.isDark ? '0 2px 50px rgba(0,145,204,0.4)' : 'none' }}>
+            <TextType text={HERO.titleLines.join('\n')} as="span" typingSpeed={46} initialDelay={350} loop={false} showCursor cursorCharacter="_" cursorClassName="text-[#0091CC]" />
+          </div>
+        </FadeIn>
+
+        <FadeIn delay={0.22}>
+          <p style={{ fontFamily: FONT, fontSize: 'clamp(17px, 1.9vw, 22px)', fontWeight: 500, lineHeight: 1.65, color: t.sub, maxWidth: 780, margin: '32px 0 48px', wordBreak: 'keep-all' }}>{HERO.subtitle}</p>
+        </FadeIn>
+
+        <FadeIn delay={0.3}>
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+            {HERO.ctas.map((cta) => (
+              <a key={cta.label} href={cta.href} target="_blank" rel="noopener noreferrer"
+                style={{ display: 'inline-flex', alignItems: 'center', padding: '14px 26px', fontFamily: FONT, fontSize: 15, fontWeight: 700, borderRadius: 9999, textDecoration: 'none', transition: 'transform 200ms',
+                  ...(cta.primary ? { background: ACCENT, color: '#fff', boxShadow: `0 8px 24px ${ACCENT}59` } : { background: t.isDark ? 'rgba(255,255,255,0.08)' : '#fff', color: t.isDark ? '#fff' : ACCENT, border: `1.5px solid ${t.isDark ? 'rgba(255,255,255,0.24)' : 'rgba(0,145,204,0.3)'}` }) }}
+                onMouseEnter={(e) => { e.currentTarget.style.transform = 'translateY(-3px)' }} onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)' }}>{cta.label}</a>
+            ))}
+            <AskChip prompt="양건호는 어떤 사람?" t={t} />
+          </div>
+        </FadeIn>
+
+        <FadeIn delay={0.4}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 'clamp(24px, 3.4vw, 52px)', marginTop: 'clamp(56px, 8vh, 88px)', maxWidth: 960, borderTop: `1px solid ${t.line}`, paddingTop: 'clamp(32px, 4vh, 48px)' }}>
+            {STATS.map((s) => (
+              <div key={s.label}>
+                <div style={{ fontFamily: FONT, fontSize: 'clamp(36px, 4.2vw, 50px)', fontWeight: 800, color: t.ink, lineHeight: 0.96, letterSpacing: '-0.035em' }}>
+                  <CountUp value={s.value} />{'unit' in s && s.unit && <span style={{ fontSize: '0.42em', fontWeight: 700, marginLeft: 3, color: t.isDark ? BLUE_LIGHT : ACCENT }}>{s.unit}</span>}
+                </div>
+                <div style={{ fontFamily: FONT, fontSize: 13, color: t.sub, marginTop: 14, fontWeight: 600, lineHeight: 1.45, wordBreak: 'keep-all' }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </FadeIn>
+      </motion.div>
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────
+// About + STACK 마퀴
+// ─────────────────────────────────────────────
+
+function AboutStackSlide({ t }: { t: Theme }) {
+  return (
+    <section style={{ position: 'absolute', inset: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: 'flex-start', background: t.sec }}>
+      <SectionBg t={t} />
+      <div style={{ maxWidth: 1180, margin: '0 auto', width: '100%', padding: 'clamp(72px, 11vh, 128px) clamp(28px, 6vw, 96px) clamp(20px, 3vh, 36px)', position: 'relative', zIndex: 1 }}>
+        <Kicker no="01" label="ABOUT · 자기소개" />
+        <blockquote style={{ margin: '0 0 clamp(16px,2.2vh,28px)', padding: '16px 24px', borderLeft: `3px solid ${ACCENT}`, background: t.accentSoft, borderRadius: '0 12px 12px 0', fontFamily: FONT, fontSize: 'clamp(15px, 1.7vw, 19px)', fontWeight: 700, lineHeight: 1.48, color: t.ink, letterSpacing: '-0.015em', wordBreak: 'keep-all' }}>
+          {NEXON_QUOTE}
+          <div style={{ fontSize: 12, fontWeight: 600, color: ACCENT, marginTop: 8 }}>— 넥슨 메이플AX실 채용 공고</div>
+        </blockquote>
+        <div style={{ maxWidth: 900, display: 'flex', flexDirection: 'column', gap: 'clamp(8px,1.2vh,14px)', marginBottom: 'clamp(16px,2.4vh,28px)' }}>
+          {ABOUT.split('\n\n').map((para, i) => (
+            <p key={i} style={{ fontFamily: FONT, fontSize: 'clamp(14px,1.35vw,16.5px)', lineHeight: 1.62, color: t.sub, margin: 0, fontWeight: 500, wordBreak: 'keep-all' }}>{para}</p>
+          ))}
+        </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {KEY_TRAITS.map((kt) => (
+            <span key={kt} style={{ fontFamily: FONT, fontSize: 12.5, fontWeight: 600, color: t.ink, background: t.accentSoft, border: `1px solid ${ACCENT}33`, padding: '7px 13px', borderRadius: 9999, wordBreak: 'keep-all' }}>{kt}</span>
+          ))}
+        </div>
+        <div style={{ marginTop: 'clamp(14px, 2.2vh, 22px)' }}>
+          <AskChip prompt="봇 9개월 운영, 어땠어?" t={t} />
+        </div>
+      </div>
+      <div style={{ maxWidth: 1180, margin: '0 auto', width: '100%', padding: '0 clamp(28px, 6vw, 96px) clamp(28px, 4vh, 52px)', position: 'relative', zIndex: 1, marginTop: 'auto' }}>
+        <div style={{ background: BAND, borderRadius: 20, padding: 'clamp(20px, 3vh, 34px) 0', overflow: 'hidden' }}>
+          <div style={{ padding: '0 clamp(22px, 3vw, 40px)', marginBottom: 14 }}>
+            <div style={{ display: 'flex', alignItems: 'baseline', gap: 14 }}>
+              <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: BLUE_LIGHT, letterSpacing: '0.18em' }}>STACK</span>
+              <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 600, color: 'rgba(255,255,255,0.55)', letterSpacing: '0.14em' }}>직접 다루는 기술</span>
+            </div>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <Marquee items={STACK_A} duration={32} />
+            <Marquee items={STACK_B} duration={36} reverse />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────
+// 가로 카드 스택 (JD 매칭 / 케이스)
+// ─────────────────────────────────────────────
+
+function JdCard({ item, t }: { item: { n: number; jdTitle: string; jdSub: string; evidence: readonly string[] }; t: Theme }) {
+  return (
+    <PanelShell>
+      <article style={{ background: t.cardSolid, border: `1px solid ${t.cardBorder}`, borderRadius: 24, boxShadow: t.cardShadow, padding: 'clamp(26px, 3vw, 44px)', backdropFilter: t.isDark ? 'blur(12px)' : undefined }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 16, marginBottom: 'clamp(12px, 2vh, 18px)' }}>
+          <span style={{ fontFamily: FONT, fontSize: 'clamp(38px, 4.6vw, 60px)', fontWeight: 800, color: ACCENT, letterSpacing: '-0.05em', lineHeight: 0.9 }}>{String(item.n).padStart(2, '0')}</span>
+          <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: ACCENT, letterSpacing: '0.2em' }}>JD MATCH</span>
+        </div>
+        <h3 style={{ fontFamily: FONT, fontSize: 'clamp(19px, 2.4vw, 30px)', fontWeight: 800, lineHeight: 1.24, letterSpacing: '-0.03em', color: t.ink, margin: '0 0 6px', wordBreak: 'keep-all' }}>{item.jdTitle}</h3>
+        <p style={{ fontFamily: FONT, fontSize: 'clamp(12.5px, 1.15vw, 14.5px)', color: t.muted, margin: '0 0 clamp(18px, 2.6vh, 28px)', fontWeight: 600, wordBreak: 'keep-all' }}>{item.jdSub}</p>
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 'clamp(9px, 1.5vh, 14px)' }}>
+          {item.evidence.map((e, i) => (
+            <li key={i} style={{ display: 'flex', gap: 12, fontFamily: FONT, fontSize: 'clamp(12px, 1vw, 14px)', lineHeight: 1.6, color: t.sub, fontWeight: 500, wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>
+              <span style={{ color: ACCENT, fontWeight: 800, flexShrink: 0 }}>—</span>
+              <span>{e}</span>
+            </li>
+          ))}
+        </ul>
+      </article>
+    </PanelShell>
+  )
+}
+
+function CasePanel({ item, no, kicker, t }: { item: { title: string; problem: string; approach: string; result: string; bridge: string }; no: number; kicker: string; t: Theme }) {
+  const rows = [
+    { label: '문제', sub: 'Problem', body: item.problem, c: '#E5615A' },
+    { label: '접근', sub: 'Approach', body: item.approach, c: '#F2A93B' },
+    { label: '결과', sub: 'Result', body: item.result, c: '#3FAE7E' },
+    { label: '넥슨 연결', sub: 'Bridge', body: item.bridge, c: ACCENT },
+  ]
+  return (
+    <PanelShell>
+      <article style={{ background: t.cardSolid, border: `1px solid ${t.cardBorder}`, borderRadius: 24, boxShadow: t.cardShadow, padding: 'clamp(28px, 3vw, 48px)', backdropFilter: t.isDark ? 'blur(12px)' : undefined }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 16, marginBottom: 'clamp(14px, 2.2vh, 24px)' }}>
+          <span style={{ fontFamily: FONT, fontSize: 'clamp(40px, 5vw, 64px)', fontWeight: 800, color: ACCENT, letterSpacing: '-0.05em', lineHeight: 0.9 }}>{String(no).padStart(2, '0')}</span>
+          <span style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: ACCENT, letterSpacing: '0.2em' }}>{kicker}</span>
+        </div>
+        <h3 style={{ fontFamily: FONT, fontSize: 'clamp(21px, 2.7vw, 34px)', fontWeight: 800, lineHeight: 1.22, letterSpacing: '-0.03em', color: t.ink, margin: '0 0 clamp(22px, 3.2vh, 40px)', wordBreak: 'keep-all' }}>{item.title}</h3>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 'clamp(20px, 2.4vw, 36px)' }}>
+          {rows.map((r) => (
+            <div key={r.label} style={{ paddingTop: 13, borderTop: `2px solid ${r.c}` }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 10 }}>
+                <span style={{ fontFamily: FONT, fontSize: 15.5, fontWeight: 800, color: r.c, letterSpacing: '-0.01em' }}>{r.label}</span>
+                <span style={{ fontFamily: FONT, fontSize: 9.5, fontWeight: 700, color: t.muted, letterSpacing: '0.18em', textTransform: 'uppercase' }}>{r.sub}</span>
+              </div>
+              <p style={{ fontFamily: FONT, fontSize: 'clamp(12.5px, 1vw, 14px)', lineHeight: 1.72, color: t.sub, margin: 0, fontWeight: 500, wordBreak: 'keep-all', overflowWrap: 'anywhere' }}>{r.body}</p>
+            </div>
+          ))}
+        </div>
+      </article>
+    </PanelShell>
+  )
+}
+
+// 오른쪽에서 들어와 가운데 핀 → 왼쪽으로 scale 줄며 쌓인다.
+function HStackCard({ index, progress, children }: { index: number; progress: number; children: React.ReactNode }) {
+  const dist = index - progress
+  const x = dist > 1 ? 108 : dist >= 0 ? dist * 100 : dist * 5
+  const scale = Math.max(0.84, 1 - Math.max(0, progress - index) * 0.06)
+  const opacity = dist > 1.04 ? 0 : dist < 0 ? Math.max(0.28, 1 + dist * 0.62) : 1
+  return <div style={{ position: 'absolute', inset: 0, transform: `translateX(${x}%) scale(${scale})`, opacity, zIndex: index, willChange: 'transform, opacity', transition: 'transform 300ms cubic-bezier(0.33,1,0.68,1), opacity 280ms ease' }}>{children}</div>
+}
+
+function StackDots({ total, progress, t }: { total: number; progress: number; t: Theme }) {
+  const active = Math.round(progress)
+  return (
+    <div style={{ position: 'absolute', bottom: 'clamp(20px, 4vh, 40px)', left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 7, zIndex: 30 }}>
+      {Array.from({ length: total }).map((_, i) => (
+        <span key={i} aria-hidden style={{ width: active === i ? 26 : 8, height: 8, borderRadius: 9999, background: active === i ? ACCENT : t.line, display: 'block', transition: 'all 250ms ease' }} />
+      ))}
+    </div>
+  )
+}
+
+// 카드 배열을 가로 스택으로. 휠 1회 = 카드 1단계(subProgress).
+function CardStackSlide({ cards, subProgress, bg, t, bgVariant = 'aurora-blue' }: { cards: React.ReactNode[]; subProgress: number; bg: string; t: Theme; bgVariant?: BgVariant }) {
+  return (
+    <div style={{ position: 'absolute', inset: 0, background: bg, overflow: 'hidden' }}>
+      <SectionBg t={t} variant={bgVariant} />
+      <div style={{ position: 'absolute', inset: 0, zIndex: 1 }}>
+        {cards.map((node, i) => (
+          <HStackCard key={i} index={i} progress={subProgress}>{node}</HStackCard>
+        ))}
+      </div>
+      <StackDots total={cards.length} progress={subProgress} t={t} />
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────
+// 자격 · 우대
+// ─────────────────────────────────────────────
+
+function FitSlide({ t }: { t: Theme }) {
+  return (
+    <SlidePane bg={t.sec} t={t} center={false} bgVariant="aurora-blue">
+      <SectionHeader no="05" kicker="FIT · 자격 · 우대" title={'지원 자격은 이미 매일 굴리는 도구입니다'} t={t} />
+      <div style={{ display: 'grid', gap: 'clamp(18px, 3vh, 32px)' }}>
+        <FadeIn>
+          <div style={{ background: t.cardSolid, border: `1px solid ${t.cardBorder}`, borderRadius: 20, padding: 'clamp(22px, 2.6vw, 36px)', boxShadow: t.cardShadow, backdropFilter: t.isDark ? 'blur(12px)' : undefined }}>
+            <div style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: ACCENT, letterSpacing: '0.18em', marginBottom: 12 }}>지원 자격</div>
+            <div style={{ fontFamily: FONT, fontSize: 'clamp(17px, 1.9vw, 23px)', fontWeight: 800, color: t.ink, marginBottom: 12, letterSpacing: '-0.02em', wordBreak: 'keep-all' }}>{ELIGIBILITY.headline}</div>
+            <p style={{ fontFamily: FONT, fontSize: 'clamp(13px, 1.15vw, 15px)', lineHeight: 1.68, color: t.sub, margin: 0, fontWeight: 500, wordBreak: 'keep-all' }}>{ELIGIBILITY.body}</p>
+          </div>
+        </FadeIn>
+        <div>
+          <div style={{ fontFamily: FONT, fontSize: 11, fontWeight: 800, color: ACCENT, letterSpacing: '0.18em', marginBottom: 14 }}>우대 사항</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: 14 }}>
+            {PREFERRED.map((p, i) => (
+              <FadeIn key={p.jdTitle} delay={i * 0.06}>
+                <div style={{ height: '100%', background: t.card, border: `1px solid ${t.cardBorder}`, borderRadius: 16, padding: 'clamp(18px, 2vw, 26px)', borderTop: `2px solid ${ACCENT}` }}>
+                  <div style={{ fontFamily: FONT, fontSize: 'clamp(14px, 1.3vw, 16px)', fontWeight: 800, color: t.ink, marginBottom: 10, letterSpacing: '-0.01em', wordBreak: 'keep-all' }}>{p.jdTitle}</div>
+                  <p style={{ fontFamily: FONT, fontSize: 'clamp(12px, 1vw, 13.5px)', lineHeight: 1.62, color: t.sub, margin: 0, fontWeight: 500, wordBreak: 'keep-all' }}>{p.evidence}</p>
+                </div>
+              </FadeIn>
+            ))}
+          </div>
+        </div>
+        <div>
+          <AskChip prompt="지원 자격 충족돼?" t={t} />
+        </div>
+      </div>
+    </SlidePane>
+  )
+}
+
+// ─────────────────────────────────────────────
+// 02 ARCHITECTURE / 03 STACK / 06 GAMES — 복원 번호 섹션
+// ─────────────────────────────────────────────
+
+// 02 — content SSoT 파이프라인 5단계를 가로 스텝 플로우로. 노드 사이 화살표.
+function ArchitectureSlide({ t }: { t: Theme }) {
+  return (
+    <SlidePane bg={t.secAlt} t={t} center={false} bgVariant="shapes-flip">
+      <SectionHeader no="02" kicker="ARCHITECTURE · 이 페이지의 파이프라인" title={'스크롤부터 3D까지, 한 프레임 루프로'} t={t} />
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'clamp(10px, 1.4vw, 16px)', rowGap: 'clamp(14px, 2vh, 22px)' }}>
+        {ARCHITECTURE.steps.map((s, i) => (
+          <FadeIn key={s.n} delay={i * 0.08}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 'clamp(10px, 1.4vw, 16px)' }}>
+              <div style={{ width: 'clamp(166px, 15vw, 212px)', background: t.cardSolid, border: `1px solid ${t.cardBorder}`, borderRadius: 18, padding: 'clamp(16px, 1.6vw, 22px)', boxShadow: t.cardShadow, backdropFilter: t.isDark ? 'blur(12px)' : undefined }}>
+                <div style={{ fontFamily: FONT, fontSize: 'clamp(26px, 2.6vw, 36px)', fontWeight: 800, color: ACCENT, letterSpacing: '-0.04em', lineHeight: 0.9, marginBottom: 12 }}>{String(s.n).padStart(2, '0')}</div>
+                <div style={{ fontFamily: FONT, fontSize: 'clamp(14px, 1.2vw, 16px)', fontWeight: 800, color: t.ink, marginBottom: 8, letterSpacing: '-0.01em', wordBreak: 'keep-all' }}>{s.label}</div>
+                <p style={{ fontFamily: FONT, fontSize: 'clamp(11.5px, 0.95vw, 13px)', lineHeight: 1.55, color: t.sub, margin: '0 0 10px', fontWeight: 500, wordBreak: 'keep-all' }}>{s.desc}</p>
+                <div style={{ fontFamily: FONT, fontSize: 10.5, fontWeight: 700, color: t.isDark ? BLUE_LIGHT : ACCENT, letterSpacing: '0.04em', wordBreak: 'keep-all' }}>{s.cost}</div>
+              </div>
+              {i < ARCHITECTURE.steps.length - 1 && (
+                <span aria-hidden style={{ color: t.muted, fontSize: 18, fontWeight: 700, flexShrink: 0 }}>→</span>
+              )}
+            </div>
+          </FadeIn>
+        ))}
+      </div>
+      <div style={{ marginTop: 'clamp(20px, 3vh, 34px)' }}>
+        <AskChip prompt="이 페이지 어떻게 만들었어?" t={t} />
+      </div>
+    </SlidePane>
+  )
+}
+
+// 03 — 카테고리별 스택을 번호 매긴 매거진 리스트로. 8행 stagger.
+function StackDetailSlide({ t }: { t: Theme }) {
+  return (
+    <SlidePane bg={t.sec} t={t} center={false} bgVariant="aurora-violet">
+      <SectionHeader no="03" kicker="STACK · 직접 다루는 기술" title={'이 화면을 굴리는 전체 스택'} t={t} />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', columnGap: 'clamp(28px, 4vw, 60px)' }}>
+        {STACK_DETAIL.map((item, i) => (
+          <FadeIn key={item.category} delay={i * 0.04}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'minmax(42px, 54px) 1fr', gap: 'clamp(12px, 1.4vw, 20px)', padding: 'clamp(11px, 1.5vh, 16px) 0', borderTop: `1px solid ${t.line}`, alignItems: 'baseline' }}>
+              <span style={{ fontFamily: FONT, fontSize: 'clamp(20px, 2.2vw, 28px)', fontWeight: 800, color: t.isDark ? 'rgba(255,255,255,0.22)' : 'rgba(10,18,36,0.18)', letterSpacing: '-0.04em', lineHeight: 1 }}>{String(i + 1).padStart(2, '0')}</span>
+              <div>
+                <div style={{ fontFamily: FONT, fontSize: 10, fontWeight: 800, color: ACCENT, letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 5 }}>{item.category}</div>
+                <div style={{ fontFamily: FONT, fontSize: 'clamp(13px, 1.2vw, 15.5px)', fontWeight: 700, color: t.ink, lineHeight: 1.38, letterSpacing: '-0.01em', wordBreak: 'keep-all', marginBottom: 8 }}>{item.headline}</div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+                  {item.chips.map((c) => (
+                    <span key={c} style={{ fontFamily: FONT, fontSize: 10.5, fontWeight: 600, color: t.sub, background: t.card, border: `1px solid ${t.cardBorder}`, padding: '3px 8px', borderRadius: 9999 }}>{c}</span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </FadeIn>
+        ))}
+      </div>
+    </SlidePane>
+  )
+}
+
+// 06 — 넥슨 IP 중심 게임 이력. 번호 리스트, 첫 행(메이플) 강조.
+function GamesSlide({ t }: { t: Theme }) {
+  return (
+    <SlidePane bg={t.secAlt} t={t} center={false} bgVariant="shapes-flip">
+      <SectionHeader no="06" kicker="GAMES · 넥슨 IP 경험" title={'플레이어로 쌓은 게임 도메인 이해'} t={t} />
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'clamp(10px, 1.5vh, 16px)' }}>
+        {GAMES.map((g, i) => (
+          <FadeIn key={g.title} delay={i * 0.06}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'minmax(44px, 58px) minmax(116px, 188px) 1fr', gap: 'clamp(12px, 2vw, 24px)', alignItems: 'baseline', padding: 'clamp(15px, 2vh, 21px) clamp(18px, 2vw, 26px)', background: i === 0 ? t.accentSoft : t.card, border: i === 0 ? `1.5px solid ${ACCENT}66` : `1px solid ${t.cardBorder}`, borderRadius: 16 }}>
+              <span style={{ fontFamily: FONT, fontSize: 'clamp(20px, 2.2vw, 28px)', fontWeight: 800, color: ACCENT, letterSpacing: '-0.04em', lineHeight: 1 }}>{String(i + 1).padStart(2, '0')}</span>
+              <div>
+                <div style={{ fontFamily: FONT, fontSize: 'clamp(15px, 1.5vw, 19px)', fontWeight: 800, color: t.ink, letterSpacing: '-0.02em', wordBreak: 'keep-all' }}>{g.title}</div>
+                <div style={{ fontFamily: FONT, fontSize: 12, fontWeight: 600, color: t.isDark ? BLUE_LIGHT : ACCENT, marginTop: 4 }}>{g.period}</div>
+              </div>
+              <p style={{ fontFamily: FONT, fontSize: 'clamp(12.5px, 1.1vw, 14.5px)', lineHeight: 1.6, color: t.sub, margin: 0, fontWeight: 500, wordBreak: 'keep-all' }}>{g.detail}</p>
+            </div>
+          </FadeIn>
+        ))}
+      </div>
+      <div style={{ marginTop: 'clamp(18px, 2.6vh, 30px)' }}>
+        <AskChip prompt="메이플 어디까지 했어?" t={t} />
+      </div>
+    </SlidePane>
+  )
+}
+
+// ─────────────────────────────────────────────
+// Closing + Footer
+// ─────────────────────────────────────────────
+
+function NexonFooter() {
+  const links = [
+    { label: 'Email', value: CONTACT.email, href: `mailto:${CONTACT.email}` },
+    { label: 'GitHub', value: 'github.com/2rami', href: CONTACT.github },
+    { label: 'Live', value: 'debimarlene.com', href: CONTACT.domain },
+  ]
+  return (
+    <footer style={{ position: 'relative', background: BAND, color: '#fff', overflow: 'hidden' }}>
+      <div style={{ padding: 'clamp(64px, 9vh, 110px) clamp(28px, 6vw, 96px) clamp(44px, 6vh, 72px)' }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto', width: '100%' }}>
+          <div style={{ fontFamily: FONT, fontSize: 'clamp(34px, 5.4vw, 68px)', fontWeight: 800, letterSpacing: '-0.03em', lineHeight: 1.18, wordBreak: 'keep-all' }}>생성형 AI 제작 도구를<br /><span style={{ color: BLUE_LIGHT }}>브라우저에서 끝까지 만드는 사람</span>이 되고 싶습니다.</div>
+        </div>
+      </div>
+      <div style={{ height: 1, background: 'rgba(255,255,255,0.2)', width: '100%' }} />
+      <div style={{ padding: 'clamp(28px, 4vh, 44px) clamp(28px, 6vw, 96px) clamp(36px, 5vh, 56px)' }}>
+        <div style={{ maxWidth: 1180, margin: '0 auto', width: '100%' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 20 }}>
+            {links.map((l) => (
+              <a key={l.label} href={l.href} target="_blank" rel="noopener noreferrer" style={{ textDecoration: 'none' }}>
+                <div style={{ fontFamily: FONT, fontSize: 11, color: BLUE_LIGHT, letterSpacing: '0.16em', fontWeight: 700, marginBottom: 8 }}>{l.label.toUpperCase()}</div>
+                <div style={{ fontFamily: FONT, fontSize: 16, color: '#fff', fontWeight: 600 }}>{l.value}</div>
+              </a>
+            ))}
+          </div>
+          <div style={{ fontFamily: FONT, fontSize: 12, color: 'rgba(255,255,255,0.4)', marginTop: 36 }}>양건호 (Geonho Yang) · 2026 · NEXON 메이플AX실 웹 프론트엔드 엔지니어 인턴 지원</div>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+function ClosingFooterSlide({ t }: { t: Theme }) {
+  return (
+    <div style={{ background: t.secAlt }}>
+      <section style={{ minHeight: '100vh', position: 'relative', overflow: 'hidden', display: 'flex', flexDirection: 'column', justifyContent: 'center', padding: 'clamp(48px, 6vw, 96px)' }}>
+        <SectionBg t={t} variant="ballpit" />
+        <div style={{ maxWidth: 1080, margin: '0 auto', width: '100%', position: 'relative', zIndex: 1 }}>
+          <Kicker label="CLOSING" />
+          <div style={{ fontFamily: FONT, fontSize: 'clamp(28px, 4.6vw, 58px)', fontWeight: 800, lineHeight: 1.24, letterSpacing: '-0.035em', color: t.ink, wordBreak: 'keep-all' }}>
+            <TextType text={'AI 제작 도구를 브라우저에서 끝까지 만드는 프론트엔드가 되겠습니다.'} as="span" typingSpeed={45} initialDelay={300} loop={false} showCursor cursorCharacter="_" startOnVisible cursorClassName="text-[#0091CC]" />
+          </div>
+          <p style={{ fontFamily: FONT, fontSize: 'clamp(15px, 1.7vw, 20px)', fontWeight: 500, lineHeight: 1.65, color: t.sub, margin: 'clamp(24px, 3.6vh, 44px) 0 0', maxWidth: 720, wordBreak: 'keep-all' }}>메이플AX실이 지향하는 방향은, 제가 이미 손으로 만들어 온 것과 같습니다.</p>
+          <div style={{ marginTop: 'clamp(24px, 3.6vh, 40px)' }}>
+            <AskChip prompt="왜 넥슨 지원했어?" t={t} />
+          </div>
+          <div style={{ marginTop: 'clamp(28px, 4vh, 48px)', display: 'flex', alignItems: 'center', gap: 10, color: t.muted, fontFamily: FONT, fontSize: 12.5, fontWeight: 600 }}>
+            <span>아래로 스크롤</span>
+            <motion.span animate={{ y: [0, 5, 0] }} transition={{ duration: 1.5, repeat: Infinity }}>↓</motion.span>
+          </div>
+        </div>
+      </section>
+      <NexonFooter />
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────
+// 페이지
+// ─────────────────────────────────────────────
+
+export default function PageFrontendDeck() {
+  const [isDark, setIsDark] = useState(false) // 라이트모드가 기본
+  const t = makeTheme(isDark)
+
+  useEffect(() => {
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    window.scrollTo(0, 0)
+    return () => { document.body.style.overflow = prevOverflow }
+  }, [])
+
+  // 슬라이드가 바뀌면 그 섹션 대사를 캐릭터 말풍선으로 — 스크롤 없는 덱의 상호작용 보강
+  const handleIndexChange = useCallback((i: number) => {
+    const text = SECTION_BUBBLES[i]
+    if (text) window.dispatchEvent(new CustomEvent('nexon:char-say', { detail: { text } }))
+  }, [])
+
+  const jdCards = JD_MATCHES.map((jd) => <JdCard key={jd.n} item={jd} t={t} />)
+  const caseCards = CASES.map((c) => <CasePanel key={c.no} item={c} no={c.no} kicker="CASE" t={t} />)
+
+  const slides: Slide[] = [
+    { node: <Hero t={t} /> },
+    {
+      node: (
+        <Statement
+          kicker="MANIFESTO"
+          text={'디자인 설계와 프론트엔드 구현을\n한 사람이 합니다.'}
+          sub="화면을 그리는 데서 멈추지 않고 Rust로 GPU 터미널까지 직접 짰습니다. 브라우저에서 시각 요소를 편집하고 실시간으로 협업하는 제작 도구 — 이미 만들어 온 방향입니다."
+          bg={t.secAlt}
+          t={t}
+          bgVariant="shapes"
+        />
+      ),
+    },
+    { node: <AboutStackSlide t={t} /> },
+    { node: <ArchitectureSlide t={t} /> },
+    { node: <StackDetailSlide t={t} /> },
+    { render: (sub) => <CardStackSlide cards={jdCards} subProgress={sub} bg={t.sec} t={t} bgVariant="shapes" />, substeps: JD_MATCHES.length - 1 },
+    { node: <FitSlide t={t} /> },
+    { node: <GamesSlide t={t} /> },
+    { render: (sub) => <CardStackSlide cards={caseCards} subProgress={sub} bg={t.secAlt} t={t} bgVariant="aurora-violet" />, substeps: CASES.length - 1 },
+    { node: <ClosingFooterSlide t={t} />, scroll: true },
+  ]
+
+  return (
+    <div style={{ fontFamily: FONT, color: t.ink, letterSpacing: '-0.01em', background: t.pageBg, minHeight: '100vh', overflowX: 'clip' }}>
+      <ThemeToggle isDark={isDark} toggle={() => setIsDark((v) => !v)} />
+      <MapleChatbot roam={false} intro="안녕하세요, 디지털 클론 양건호입니다. 롯데월드 메이플 콜라보 때 전광판 타워에서 QR로 소환됐던 캐릭터처럼, 우측 아래에서 대기 중이에요. 프론트엔드나 kasaterm, 뭐든 물어보세요." />
+      <SlideDeck slides={slides} accent={ACCENT} onIndexChange={handleIndexChange} />
+    </div>
+  )
+}

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/content/frontend.ts
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/content/frontend.ts
@@ -1,0 +1,268 @@
+/**
+ * 넥슨 AI본부 메이플AX실 — 웹 프론트엔드 엔지니어 (인턴) 지원용
+ * 컨텐츠 SSoT — kasaterm(Rust GPU 터미널) · debi-marlene 대시보드 · 이 포트폴리오 자체 기반
+ * 공고: careers.nexon.com/recruit/10027
+ */
+
+export const HERO = {
+  jobCode: 'WEB FRONTEND',
+  badge: 'NEXON · AI본부 메이플AX실 · 웹 프론트엔드 엔지니어 인턴 지원',
+  titleLines: ['안녕하세요.', '생성형 AI 제작 도구를', '브라우저에서 직접 만드는 프론트엔드입니다.'],
+  // 호환성용 평문 (BlurText 등 일부 컴포넌트가 string을 기대)
+  title: '안녕하세요. 생성형 AI 제작 도구를 브라우저에서 직접 만드는 프론트엔드입니다.',
+  highlightWord: '제작 도구',
+  subtitle:
+    'Rust로 GPU 터미널을 짜고, React·Vite로 라이브 서비스를 굴리고, 지금 보고 계신 이 페이지까지 — 디자인 설계와 프론트엔드 구현을 한 사람이 합니다.',
+  meta: [
+    { label: 'ROLE', value: '웹 프론트엔드 엔지니어 인턴' },
+    { label: 'TEAM', value: '넥슨 · AI본부 메이플AX실' },
+    { label: 'FOCUS', value: '생성형 AI 제작 도구 · 3D 렌더 · 리치 UI' },
+    { label: 'STACK', value: 'React · Vite · TS · three.js · GSAP' },
+    { label: 'ALSO', value: 'Rust · wgpu — kasaterm GPU 터미널' },
+  ],
+  ctas: [
+    { label: 'GitHub · 2rami', href: 'https://github.com/2rami', primary: true },
+    { label: 'Live · debimarlene.com', href: 'https://debimarlene.com', primary: false },
+    { label: '이 페이지가 곧 포트폴리오', href: 'https://debimarlene.com/portfolio/nexon/frontend', primary: false },
+  ],
+} as const
+
+export const STATS = [
+  { label: 'GPU 터미널 메모리 최적화', value: '113', unit: 'MB', sub: 'kasaterm — 1.25GB에서 약 91% 절감한 렌더 최적화' },
+  { label: '라이브 React 서비스 운영', value: '9', unit: '개월+', sub: 'debimarlene.com 대시보드·웹패널 (Vite·TS·Tailwind)' },
+  { label: '직접 구성한 3D·스크롤 엔진', value: '3', unit: '종', sub: '이 페이지 — three.js · GSAP ScrollTrigger · Lenis' },
+  { label: '시각디자인 → 프론트엔드', value: '4', unit: '년', sub: '디자인 설계와 구현을 한 사람이 (디자이너 출신)' },
+] as const
+
+export const ABOUT = `저는 디자이너 출신 프론트엔드 엔지니어입니다. 시각디자인 4년을 전공한 뒤, 화면을 그리는 데서 멈추지 않고 직접 구현까지 하고 싶어 프론트엔드로 넘어왔습니다. Rust로 GPU 터미널(kasaterm)을 밑바닥부터 혼자 짜면서 렌더링 파이프라인과 성능 최적화를 다뤘고, React·Vite·TypeScript로 158개 Discord 서버 봇의 운영 대시보드를 9개월째 라이브로 굴리고 있습니다. 지금 보고 계신 이 포트폴리오 페이지도 React 19 + Vite + TypeScript로, GSAP·Lenis·three.js·framer-motion을 직접 엮어 만들었습니다. MCP·hook·서브에이전트로 개발 하네스를 직접 구축해, 생성형 AI 모델을 실제 인터페이스에 연결하는 일을 반복해 왔습니다. 메이플AX실이 만드는 "브라우저에서 시각 요소를 자유롭게 편집하고 실시간으로 협업하는 생성형 AI 제작 도구"는 제가 이미 손으로 만들어 온 것과 정확히 같은 방향입니다.`
+
+export const JD_MATCHES = [
+  {
+    n: 1,
+    jdTitle: '생성형 AI 제작 도구의 웹 프론트엔드 개발·아키텍처 설계',
+    jdSub: '제작 도구형 웹 애플리케이션의 프론트엔드 구조 설계와 구현',
+    evidence: [
+      'kasaterm — Rust로 GPU 터미널을 밑바닥부터 직접 만들고, 그 위에 자연어로 도구를 조립하는 GUI 레이어를 얹었습니다. wgpu 셀 렌더러, 입력 → vt100 파서 → 셀 그리드 → GPU 프레임으로 이어지는 파이프라인과 pane 드래그 아키텍처를 혼자 설계·구현했습니다',
+      'debi-marlene 대시보드/웹패널 — 158개 Discord 서버 봇의 운영 콘솔을 React·Vite·TypeScript·Tailwind로 직접 설계해 9개월째 라이브 운영 중입니다. 서버 설정·크레딧 결제·이미지 생성 UI까지 프론트 전체를 혼자 맡았습니다',
+      '지금 보고 계신 이 포트폴리오 페이지 자체가 제작 도구형 프론트엔드입니다. 콘텐츠를 SSoT 한 파일로 분리하고 스크롤리텔링 컴포넌트를 props 구동으로 설계해, 직군만 갈아끼우면 새 지원 페이지가 찍혀 나오는 구조로 만들었습니다',
+      'MCP·hook·서브에이전트로 개발 하네스를 직접 구축했습니다. 도구를 조합해 워크플로우를 만드는 사고방식이 곧 제작 도구를 설계하는 관점과 같습니다',
+    ],
+  },
+  {
+    n: 2,
+    jdTitle: '내부/외부 생성형 AI 모델과 연동되는 고성능 웹 애플리케이션',
+    jdSub: 'AI 모델을 프론트엔드에 연결하고 실시간으로 렌더링',
+    evidence: [
+      '이 페이지 하단 챗봇은 Anthropic Managed Agent를 `/api/portfolio/ask/stream` 으로 붙여 SSE 스트리밍으로 응답합니다. 프론트에서 토큰이 도착하는 대로 실시간 렌더링하고, 취소·큐잉·이미지 첨부까지 처리합니다',
+      'kasaterm 프록시 — `ANTHROPIC_BASE_URL` 을 가로채 SSE 응답을 tee 하고, LiteLLM 으로 여러 모델 백엔드를 교체할 수 있게 구성했습니다. 내부/외부 모델을 한 인터페이스로 스위칭합니다',
+      'debi-marlene 봇 백엔드는 Anthropic Managed Agents(claude-haiku-4-5)와 Modal Gemma4 LoRA를 `CHAT_BACKEND` 환경변수 한 줄로 바꿔 낍니다. RAG·LangGraph 오케스트레이션까지 프론트와 연동했습니다',
+      '이미지 생성 — 자연어를 도트 스프라이트로 만드는 파이프라인, ComfyUI·codex imagegen 등 멀티모달 생성 모델을 실제 제작 워크플로우에 연결해 써 왔습니다',
+    ],
+  },
+  {
+    n: 3,
+    jdTitle: '캔버스·드래그앤드롭·실시간 프리뷰·협업 — 제작 도구형 리치 UI/UX',
+    jdSub: '단순 폼을 넘어선 인터랙티브 편집 인터페이스',
+    evidence: [
+      'kasaterm — pane 을 드래그해 merge/split 하는 드롭존, 파일트리 DnD, 이미지 pane(키티 그래픽 프로토콜), Warp 풍 명령 블록 인터랙션을 직접 구현했습니다. 터미널을 편집 가능한 캔버스처럼 다뤘습니다',
+      '이 페이지의 메이플 캐릭터는 스크롤을 따라 화면 네 코너를 순회하고, 드래그로 옮길 수 있습니다. 도킹 슬롯을 공유하는 컨텍스트가 매 프레임 lerp/spring 으로 캐릭터를 추종시킵니다. 롯데월드 메이플 콜라보 때 QR 로그인으로 내 캐릭터가 전광판 타워에 뜨던 경험에서 가져온 인터랙션입니다',
+      'GSAP ScrollTrigger + Lenis 스무스 스크롤로 스크롤리텔링을 만들었습니다. 챕터 전환과 JD 매칭 카드가 스크롤 위치에 실시간으로 반응합니다',
+      'kasaspace 아로나 UI — EdgeRail 접기, 멀티뷰, 실시간 pane 협업(board 동기화)으로 여러 에이전트가 같은 화면에서 함께 일하는 인터페이스를 구현했습니다',
+    ],
+  },
+  {
+    n: 4,
+    jdTitle: '일관된 UI 품질과 개발 생산성을 위한 컴포넌트 디자인 시스템',
+    jdSub: '재사용 컴포넌트와 디자인 토큰으로 품질·생산성 동시 확보',
+    evidence: [
+      '시각디자인 4년 전공에 실제 디자인 시스템을 운영합니다. 브랜드 컬러 토큰(`colors.ts`), kasaterm 테마 토큰(`theme.rs` · AtomicU32 원자적 교체), 한국어 디자인 스킬(kdesign)까지 직접 만들었습니다',
+      '이 포트폴리오는 콘텐츠 SSoT + 재사용 스크롤리텔링 컴포넌트(JD 매칭·케이스 스택·아키텍처 다이어그램)를 props 구동으로 설계했습니다. 지금 이 웹 프론트엔드 지원 페이지도 그 구조에서 콘텐츠만 갈아끼워 찍어냈습니다',
+      '디자이너 출신이라 컴포넌트의 시각 품질과 구현을 한 사람이 책임집니다. 디자인과 개발을 오갈 때 생기는 전달 손실·왕복 비용이 없습니다',
+      'Paperlogy·NEXON Lv2 Gothic 웹폰트, P3 색공간·Bradford 색 변환까지 다루며 색과 타이포의 일관성을 코드로 관리해 왔습니다',
+    ],
+  },
+] as const
+
+export const PREFERRED = [
+  {
+    jdTitle: 'Three.js · WebGL 3D 그래픽스 렌더링 최적화',
+    evidence:
+      '이 페이지 배경은 three.js 로 만든 3종(Ballpit · Aurora · Lightning)을 섹션별로 교체합니다. kasaterm 에서는 wgpu 로 GPU 셀 렌더러를 짜면서 damage tracking 으로 바뀐 셀만 다시 그리고, 메모리를 1.25GB → 113MB 로 줄였습니다. GPU 렌더 파이프라인을 웹과 네이티브 양쪽에서 다뤄 봤습니다.',
+  },
+  {
+    jdTitle: 'WebSocket · 실시간 동시 편집/협업',
+    evidence:
+      '여러 에이전트가 같은 화면에서 협업하도록 pane 단위 상태 공유(board 동기화)를 직접 설계·구현했습니다. Yjs·CRDT 는 아직 써 보지 않았지만, 실시간 상태를 어떻게 공유하고 병합하는지에 대한 구조는 kasaterm 협업 시스템에서 손으로 만들어 봤습니다.',
+  },
+  {
+    jdTitle: '멀티모달 생성형 AI 서비스에 대한 이해',
+    evidence:
+      '텍스트·이미지·음성을 모두 다뤄 왔습니다. 자연어 → 도트 스프라이트 생성, ComfyUI 이미지 파이프라인, Qwen3.5-Omni 음성 이해 + CosyVoice3 TTS 를 실제 서비스에 연결했습니다. 모델의 출력을 사용자 경험으로 잇는 작업을 반복해 왔습니다.',
+  },
+] as const
+
+export const ELIGIBILITY = {
+  headline: 'HTML5·CSS3·JS(ES6+)·TypeScript · React·Vite — 라이브로 굴려 온 스택',
+  body:
+    'debi-marlene 대시보드와 웹패널을 React·Vite·TypeScript·Tailwind로 직접 만들어 9개월째 라이브 운영 중입니다. 상태 관리·라우팅·PWA·Cloudflare 캐시까지 실제 서비스 환경에서 굴렸습니다. 지금 보고 계신 이 포트폴리오 페이지도 React 19 + Vite + TypeScript로, GSAP·Lenis·three.js·framer-motion을 직접 엮어 만들었습니다. 그 위에 Rust로 GPU 터미널(kasaterm)까지 혼자 짜면서 렌더링 파이프라인과 성능 최적화를 밑바닥부터 다뤘습니다. 지원 자격의 HTML5·CSS3·JavaScript(ES6+)·TypeScript·React·Vite는 배워서 아는 게 아니라 매일 굴리는 도구입니다.',
+} as const
+
+export const CHARACTER = {
+  name: '프로즌샤',
+  server: '오로라',
+  job: '아크메이지(썬,콜)',
+  level: 284,
+  experience: '약 16년 (2009 ~ )',
+  achievement: {
+    title: '하드 세렌 파티 격파',
+    sub: '메이플 최상위 콘텐츠 · 게임 도메인 이해의 증거',
+  },
+} as const
+
+export const GAMES = [
+  {
+    title: '메이플스토리',
+    period: '2009 ~ 약 16년',
+    detail: '오로라 · 프로즌샤 · 아크메이지(썬,콜) · 검은 마법사 보스 격파 · 하드 세렌 파티 격파',
+  },
+  { title: '블루아카이브', period: '약 3년', detail: '넥슨게임즈 자회사 IP. 만렙 유지, 메인·이벤트 스토리 완주' },
+  {
+    title: '이터널리턴',
+    period: '1년+',
+    detail: '제 봇(데비&마를렌)의 본 IP — 패치노트 RAG·캐릭터 시스템까지 사용자 시점으로 학습',
+  },
+  { title: '더 파이널스', period: '시즌 단위', detail: 'Embark Studios (넥슨 자회사). 친구들과 라이트 플레이' },
+  { title: '서든어택', period: '학창 시절', detail: '넥슨 본사 IP. 친구들과 함께한 입문 FPS' },
+] as const
+
+export const ARCHITECTURE = {
+  title: '이 포트폴리오의 프론트엔드 파이프라인 — 스크롤부터 3D까지',
+  steps: [
+    {
+      n: 1,
+      label: 'Lenis · 스무스 스크롤',
+      desc: '네이티브 스크롤을 가로채 관성·보간으로 다시 그립니다. duration·lerp·wheelMultiplier 를 직접 튜닝했습니다',
+      cost: 'raf 기반 · 프레임당 1회 보간',
+    },
+    {
+      n: 2,
+      label: 'GSAP ticker 통합',
+      desc: 'Lenis 의 raf 를 GSAP ticker 에 물려 스크롤과 애니메이션을 한 루프로 합치고, ScrollTrigger 로 섹션을 스크롤 위치에 맞춰 reveal',
+      cost: 'lagSmoothing 0 · 단일 프레임 루프',
+    },
+    {
+      n: 3,
+      label: 'CharacterDock · 캐릭터 추종',
+      desc: '도킹 슬롯을 공유하는 컨텍스트가 매 프레임 lerp/spring 으로 캐릭터를 목표 위치까지 따라잡게 합니다',
+      cost: 'dockEl 슬롯 · 16% 비율 spring',
+    },
+    {
+      n: 4,
+      label: 'three.js 배경 렌더',
+      desc: 'Ballpit·Aurora·Lightning 을 WebGL 로 렌더하고 섹션별로 교체. 화면 밖에선 GPU 부하를 낮춥니다',
+      cost: '가시 영역만 활성',
+    },
+    {
+      n: 5,
+      label: 'content SSoT → 직군 페이지',
+      desc: '콘텐츠를 한 파일로 모으고 컴포넌트를 props 구동으로 설계해, 직군만 바꾸면 새 지원 페이지가 나옵니다',
+      cost: '이 웹 프론트엔드 페이지가 그 산출물',
+    },
+  ],
+} as const
+
+export const TECH_STACK = {
+  frontend: [
+    { label: '프레임워크', value: 'React 19 · Vite · TypeScript · Tailwind' },
+    { label: '스크롤·모션', value: 'GSAP ScrollTrigger · Lenis · framer-motion' },
+    { label: '3D·그래픽스', value: 'three.js (Ballpit · Aurora · Lightning) · WebGL' },
+    { label: '배포', value: 'PWA (vite-plugin-pwa) · Cloudflare 캐시 · debimarlene.com' },
+  ],
+  native: [
+    { label: 'GPU 터미널', value: 'kasaterm — Rust · wgpu · winit' },
+    { label: '렌더', value: 'vt100 파서 · 셀 그리드 · damage tracking · P3/Bradford' },
+  ],
+  ai: [
+    { label: '모델 연동', value: 'Anthropic Managed Agents · SSE 스트리밍' },
+    { label: '하네스', value: 'MCP · hook · 서브에이전트 · LiteLLM 멀티모델' },
+    { label: '오케스트레이션', value: 'RAG · LangGraph StateGraph' },
+  ],
+} as const
+
+export const CASES = [
+  {
+    no: 1,
+    title: 'kasaterm — GPU 터미널 메모리 1.25GB → 113MB',
+    problem:
+      'Rust GPU 터미널 초기 구현이 메모리를 1.25GB 넘게 먹었습니다. 변화가 없는 프레임에도 셀을 매번 다시 그리는 구조가 원인이었습니다.',
+    approach:
+      'damage tracking 을 도입해 바뀐 셀(dirty)만 다시 그리고, 변화 없는 프레임은 GPU 제출을 통째로 건너뛰게 했습니다. 글리프 아틀라스와 색 파이프라인(P3/Bradford)도 재구성했습니다.',
+    result:
+      '메모리를 113MB 로 약 91% 줄였습니다. GPU 프레임을 PNG 로 리드백해 렌더 결과를 자동 검증하는 루프까지 붙여, 회귀를 눈이 아니라 스크립트로 잡습니다.',
+    bridge:
+      'GPU 렌더 파이프라인을 밑바닥에서 최적화한 경험 — three.js/WebGL 렌더링 최적화 우대사항과 그대로 이어집니다.',
+  },
+  {
+    no: 2,
+    title: '이 포트폴리오 — content SSoT + props 구동 컴포넌트로 직군별 페이지',
+    problem:
+      '지원처마다 페이지를 새로 짜면 컴포넌트가 복제되고 유지보수가 무너집니다. 콘텐츠와 화면이 뒤엉키는 게 문제였습니다.',
+    approach:
+      '콘텐츠를 content 파일 하나로 모으고, JD 매칭·케이스 스택·아키텍처 다이어그램을 props 만 받는 순수 컴포넌트로 설계했습니다. 페이지는 콘텐츠를 주입하는 얇은 오케스트레이터로 남겼습니다.',
+    result:
+      '넥슨 LLM·서비스·QA, 사이오닉, 코코네, 그리고 지금 이 웹 프론트엔드 버전까지 같은 엔진에서 콘텐츠만 갈아끼워 찍어냈습니다.',
+    bridge: '컴포넌트 디자인 시스템으로 개발 생산성을 확보하는 방식 그 자체입니다.',
+  },
+  {
+    no: 3,
+    title: '캐릭터 도킹 인터랙션 — 스크롤을 따라다니는 캐릭터',
+    problem: '정적인 포트폴리오는 기억에 남지 않습니다. 시선을 끌면서도 읽기를 방해하지 않는 인터랙션이 필요했습니다.',
+    approach:
+      '롯데월드 메이플 콜라보에서 QR 로그인으로 내 캐릭터가 전광판 타워에 뜨던 경험을 그대로 가져왔습니다. 도킹 슬롯을 공유하는 컨텍스트를 만들고, 캐릭터가 매 프레임 lerp/spring 으로 스크롤 위치를 추종하며 네 코너를 순회하게 했습니다. 드래그로 옮길 수도 있습니다.',
+    result: '캐릭터가 페이지 전체를 따라다니다 하단 챗봇으로 이어집니다. 인터랙션이 곧 내비게이션이 됐습니다.',
+    bridge: '실시간 프리뷰·드래그 인터랙션을 제작 도구 UI 에 녹여 넣는 감각.',
+  },
+  {
+    no: 4,
+    title: 'Lenis × GSAP — 스크롤과 애니메이션을 한 루프로',
+    problem: '스무스 스크롤과 GSAP 애니메이션이 각자 raf 를 돌리면 프레임이 어긋나 스크롤이 끊깁니다.',
+    approach:
+      'Lenis 의 raf 를 GSAP ticker 에 물려 단일 루프로 합치고, lagSmoothing 을 0 으로 꺼 ScrollTrigger 가 Lenis 스크롤 값을 그대로 읽게 했습니다.',
+    result: '스크롤·섹션 reveal·캐릭터 추종이 같은 프레임에서 움직여 끊김이 사라졌습니다.',
+    bridge: '프레임 예산 안에서 여러 렌더 소스를 동기화하는 성능 감각.',
+  },
+  {
+    no: 5,
+    title: 'kasaterm — pane 드래그 merge/split 드롭존',
+    problem: '터미널 분할을 키보드 단축키로만 하면 직관적이지 않습니다. 마우스로 레이아웃을 바꾸고 싶었습니다.',
+    approach:
+      'pane 을 잡아 다른 pane 위로 끌면 merge/split 드롭존이 나타나고, 놓는 위치에 따라 레이아웃이 바뀌게 했습니다. iTerm 풍 per-pane 헤더와 드롭 하이라이트도 붙였습니다.',
+    result: '마우스만으로 레이아웃을 자유롭게 재구성합니다. 드래그앤드롭 편집 인터페이스의 실전 구현입니다.',
+    bridge: 'JD 의 드래그앤드롭 제작 도구 UI 요구와 1:1 로 맞물립니다.',
+  },
+  {
+    no: 6,
+    title: 'debi-marlene 대시보드 — 158서버 운영 콘솔 React',
+    problem: '158개 서버 봇의 설정·결제·통계를 코드로만 만지는 건 지속 불가능했습니다.',
+    approach:
+      'React·Vite·TypeScript·Tailwind 로 운영 대시보드와 웹패널(PWA)을 만들고, 로그인·서버별 설정·크레딧 충전(Toss)·이미지 생성 UI 를 붙였습니다. Cloudflare 캐시로 배포했습니다.',
+    result: '9개월째 라이브. 실제 사용자와 결제가 도는 프로덕션 React 서비스를 혼자 설계·개발·운영하고 있습니다.',
+    bridge: '라이브 웹 애플리케이션을 설계부터 운영까지 혼자 책임져 본 경험.',
+  },
+] as const
+
+export const COLLAB = {
+  title: '커뮤니케이션 국제 디자인 공모전 입상',
+  problem: '3인 팀에서 졸업 전시 작품을 "인쇄 단일" vs "디지털 결합"으로 두고 의견이 갈렸습니다.',
+  approach:
+    '일정·인력·관람객 시나리오를 표로 정리해 두 안을 같은 기준 위에서 비교했습니다. 디자인 컨셉을 흐트러뜨리지 않는 선에서 인터랙티브 웹페이지 인터페이스 방향을 직접 제안했습니다.',
+  result: '시각적 일관성과 사용자 흐름을 결합한 결과물로 공모전에 입상했습니다.',
+  bridge: '협업 구성원과 소통하며 더 나은 제품 경험을 위해 주도적으로 의견을 내는 방식 — 우대사항과 맞닿아 있습니다.',
+} as const
+
+export const CONTACT = {
+  email: 'goenho0613@gmail.com',
+  github: 'https://github.com/2rami',
+  domain: 'https://debimarlene.com',
+  edu: '신구대학교 시각디자인과 졸업 (2026.02)',
+} as const

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/sections/Ch1AboutFE.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/sections/Ch1AboutFE.tsx
@@ -1,0 +1,866 @@
+import { CSSProperties, useEffect, useRef } from 'react'
+import { motion, MotionValue, useScroll, useTransform } from 'framer-motion'
+import gsap from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+import { C, FONT_BODY, FONT_DISPLAY, FONT_MONO } from '../shared/colors'
+import { STATS } from '../content/frontend'
+import { useRevealOff } from '../shared/useRevealOff'
+import useIsMobile from '../shared/useIsMobile'
+import LiveServersMarquee from '../shared/LiveServersMarquee'
+
+gsap.registerPlugin(ScrollTrigger)
+
+/**
+ * CH 1 — WHO (01 ABOUT + 02 DETAILS 통합 핀 슬라이드)
+ *
+ * 좌: CH 라벨 · 타이틀 · lede · STATS (sticky 동안 고정)
+ * 우: 6개 포인트 카드 stack — 현재 카드 + 다음 카드 미리보기 (스크롤 진행이 카드 전환 구동)
+ * 후속: pull quote (직무 연결, 자연 스크롤)
+ */
+
+const POINTS = [
+  { k: 'BUILD',  t: 'kasaterm — Rust GPU 터미널', d: 'wgpu 셀 렌더러를 밑바닥부터 직접 구현' },
+  { k: 'STACK',  t: 'React 19 + Vite + TS',      d: '158서버 대시보드 9개월 라이브 운영' },
+  { k: '3D',     t: 'three.js + wgpu 렌더',       d: 'Ballpit·Aurora·Lightning · GPU 최적화' },
+  { k: 'MOTION', t: 'GSAP + Lenis 스크롤',        d: '스크롤·모션·캐릭터 추종을 한 루프로' },
+  { k: 'AI',     t: 'Managed Agent SSE 챗봇',     d: '이 페이지 하단 · 실시간 토큰 스트리밍' },
+  { k: 'DESIGN', t: '디자인 시스템 토큰',          d: '시각디자인 4년 · 설계와 구현을 한 사람이' },
+] as const
+
+export default function Ch1About() {
+  const revealOff = useRevealOff()
+  const isMobile = useIsMobile()
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const { scrollYProgress } = useScroll({
+    target: containerRef,
+    offset: ['start start', 'end end'],
+  })
+
+  // 슬라이드용 progress — INTRO_FRAC 이후를 [0, 1] 로 remap.
+  const slideProgress = useTransform(scrollYProgress, [INTRO_FRAC, 1], [0, 1])
+
+  // 모바일은 sticky pin + scrollY transform 으로 카드 스택이 의도대로 안 잡힘 → 정적 그리드 사용
+  if (revealOff || isMobile) return <Ch1Static />
+
+  const N = POINTS.length
+  const M = N + 1 // 카드 N장 + 마지막 pull quote 1장
+
+  return (
+    <section id="about" style={{ background: C.bgWhite, position: 'relative' }}>
+      {/* 핀 슬라이드 영역 — outer 가 스크롤 길이를 만들고, inner 가 sticky */}
+      <div
+        ref={containerRef}
+        style={{
+          height: `${M * 280}vh`,
+          position: 'relative',
+        }}
+      >
+        <div
+          style={{
+            position: 'sticky',
+            top: 0,
+            height: '100vh',
+            overflow: 'hidden',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <div
+            style={{
+              width: '100%',
+              maxWidth: 1320,
+              margin: '0 auto',
+              padding: '0 clamp(20px, 6vw, 120px)',
+              display: 'grid',
+              gridTemplateColumns: isMobile ? '1fr' : 'minmax(0, 0.95fr) minmax(0, 1.05fr)',
+              gap: isMobile ? 28 : 'clamp(40px, 5vw, 88px)',
+              alignItems: 'center',
+            }}
+          >
+            <LeftIntro triggerRef={containerRef} />
+            <CardStack triggerRef={containerRef} slideProgress={slideProgress} />
+          </div>
+
+          <ProgressBar
+            scrollYProgress={scrollYProgress}
+            slideProgress={slideProgress}
+            count={M}
+            containerRef={containerRef}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function LeftIntro({ triggerRef }: { triggerRef: React.RefObject<HTMLDivElement | null> }) {
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const root = rootRef.current
+    const trigger = triggerRef.current
+    if (!root || !trigger) return
+
+    const ctx = gsap.context(() => {
+      const labelChars = root.querySelectorAll<HTMLElement>('[data-anim="label"] .ch')
+      const titleWords = root.querySelectorAll<HTMLElement>('[data-anim="title"] .word')
+      const ledeWords = root.querySelectorAll<HTMLElement>('[data-anim="lede"] .word')
+      const statBars = root.querySelectorAll<HTMLElement>('[data-anim="stat-bar"]')
+      const statValues = root.querySelectorAll<HTMLElement>('[data-anim="stat-value"]')
+      const statMeta = root.querySelectorAll<HTMLElement>('[data-anim="stat-meta"]')
+
+      // 초기 상태
+      gsap.set(labelChars, { opacity: 0, y: -10 })
+      gsap.set(titleWords, { opacity: 0, y: 48, clipPath: 'inset(0 0 100% 0)' })
+      gsap.set(ledeWords, { opacity: 0, filter: 'blur(8px)', y: 14 })
+      gsap.set(statBars, { scaleX: 0, transformOrigin: 'left center' })
+      gsap.set(statMeta, { opacity: 0, y: 12 })
+
+      // scrub timeline — 핀 outer container 를 trigger 로.
+      // start: 'top 70%' (섹션이 viewport 70% 지점 도달 — 등장 시작)
+      // end: 컨테이너 단축(450→280vh)에 맞춰 1.0 viewport. 슬라이드 시작 전 reveal 완료.
+      const tl = gsap.timeline({
+        scrollTrigger: {
+          trigger,
+          start: 'top 70%',
+          end: () => '+=' + window.innerHeight * 1.0,
+          scrub: 0.8,
+          invalidateOnRefresh: true,
+        },
+        defaults: { ease: 'power2.out' },
+      })
+
+      tl.to(labelChars, { opacity: 1, y: 0, stagger: 0.04, duration: 0.4 }, 0)
+        .to(
+          titleWords,
+          { opacity: 1, y: 0, clipPath: 'inset(0 0 0% 0)', duration: 1, stagger: 0.12 },
+          0.1,
+        )
+        .to(
+          ledeWords,
+          { opacity: 1, filter: 'blur(0px)', y: 0, duration: 0.7, stagger: 0.025 },
+          0.5,
+        )
+        .to(statBars, { scaleX: 1, duration: 0.6, stagger: 0.1, ease: 'power2.inOut' }, 0.7)
+        .to(statMeta, { opacity: 1, y: 0, duration: 0.5, stagger: 0.1 }, 0.78)
+
+      // count-up — scrub 가능하도록 timeline child tween. 0 → target 값.
+      statValues.forEach((el) => {
+        const target = parseFloat(el.dataset.value || '0')
+        const decimals = (el.dataset.value || '').includes('.') ? 1 : 0
+        const proxy = { v: 0 }
+        tl.to(
+          proxy,
+          {
+            v: target,
+            duration: 1.4,
+            ease: 'power2.out',
+            onUpdate: () => {
+              el.textContent = proxy.v.toFixed(decimals)
+            },
+          },
+          0.65,
+        )
+      })
+    }, root)
+
+    // Lenis/폰트 로드 race 회피 — 마운트 직후 한 번 + 100ms 후 한 번 더 refresh
+    ScrollTrigger.refresh()
+    const refreshId = window.setTimeout(() => ScrollTrigger.refresh(), 100)
+
+    return () => {
+      window.clearTimeout(refreshId)
+      ctx.revert()
+    }
+  }, [])
+
+  return (
+    <div ref={rootRef} style={{ display: 'flex', flexDirection: 'column', gap: 24, minWidth: 0 }}>
+      <AnimatedLabel ch="CH 1" no="01—02" kicker="WHO · ABOUT" />
+
+      <h2
+        data-anim="title"
+        style={{
+          fontFamily: FONT_DISPLAY,
+          fontSize: 'clamp(30px, 3.6vw, 48px)',
+          fontWeight: 800,
+          lineHeight: 1.12,
+          letterSpacing: '-0.028em',
+          color: C.ink,
+          margin: 0,
+          wordBreak: 'keep-all',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '0.25em',
+        }}
+      >
+        {'저는 이런 사람입니다'.split(' ').map((w, i) => (
+          <span key={i} className="word" style={{ display: 'inline-block', willChange: 'transform, opacity, clip-path' }}>
+            {w}
+          </span>
+        ))}
+      </h2>
+
+      <p
+        data-anim="lede"
+        style={{
+          fontFamily: FONT_DISPLAY,
+          fontSize: 'clamp(15px, 1.4vw, 19px)',
+          lineHeight: 1.55,
+          fontWeight: 600,
+          color: C.inkSoft,
+          margin: 0,
+          letterSpacing: '-0.018em',
+          maxWidth: 480,
+          wordBreak: 'keep-all',
+        }}
+      >
+        <LedeText />
+      </p>
+
+      <StatStripe />
+    </div>
+  )
+}
+
+function LedeText() {
+  // 단어 단위 split — 색상 강조 단어("생성형 AI 제작 도구")는 별도 묶음
+  const parts: Array<{ text: string; accent?: boolean }> = [
+    { text: '디자인 설계와 프론트엔드 구현을 한 사람이 하는 것, 그것이' },
+    { text: '생성형 AI 제작 도구', accent: true },
+    { text: '를 만드는 가장 빠른 길이라고 믿습니다.' },
+  ]
+
+  let key = 0
+  return (
+    <>
+      {parts.map((p, idx) =>
+        p.accent ? (
+          <span key={idx}>
+            {' '}
+            <span
+              className="word"
+              style={{
+                display: 'inline-block',
+                color: C.nexonBlue,
+                fontWeight: 700,
+                willChange: 'transform, opacity, filter',
+              }}
+            >
+              {p.text}
+            </span>{' '}
+          </span>
+        ) : (
+          <span key={idx}>
+            {p.text.split(' ').map((w) => (
+              <span
+                key={key++}
+                className="word"
+                style={{ display: 'inline-block', marginRight: '0.25em', willChange: 'transform, opacity, filter' }}
+              >
+                {w}
+              </span>
+            ))}
+          </span>
+        ),
+      )}
+    </>
+  )
+}
+
+function AnimatedLabel({ ch, no, kicker }: { ch: string; no: string; kicker: string }) {
+  const labelStyle: CSSProperties = {
+    fontFamily: FONT_BODY,
+    fontSize: 11,
+    fontWeight: 800,
+    letterSpacing: '0.22em',
+    textTransform: 'uppercase',
+  }
+  const line = `${ch} · ${no}`
+  return (
+    <div data-anim="label">
+      <div style={{ ...labelStyle, color: C.nexonBlue, marginBottom: 4 }}>
+        {line.split('').map((c, i) => (
+          <span key={i} className="ch" style={{ display: 'inline-block', willChange: 'transform, opacity' }}>
+            {c === ' ' ? ' ' : c}
+          </span>
+        ))}
+      </div>
+      <div style={{ ...labelStyle, color: C.inkMuted }}>
+        {kicker.split('').map((c, i) => (
+          <span key={i} className="ch" style={{ display: 'inline-block', willChange: 'transform, opacity' }}>
+            {c === ' ' ? ' ' : c}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function StatStripe() {
+  return (
+    <div
+      style={{
+        marginTop: 8,
+        display: 'grid',
+        gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+        gap: 14,
+      }}
+    >
+      {STATS.map((s, i) => {
+        const isNumeric = /^\d+(\.\d+)?$/.test(s.value)
+        return (
+          <div
+            key={s.label}
+            style={{
+              position: 'relative',
+              paddingTop: 12,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            {/* 상단 border — scaleX 0 → 1 등장 */}
+            <div
+              data-anim="stat-bar"
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                height: 2,
+                background: i === 0 ? C.nexonBlue : C.ink,
+                opacity: i === 0 ? 1 : 0.85,
+              }}
+            />
+            <div
+              style={{
+                fontFamily: FONT_DISPLAY,
+                fontSize: 'clamp(20px, 2.2vw, 28px)',
+                fontWeight: 800,
+                lineHeight: 1,
+                color: C.ink,
+                fontVariantNumeric: 'tabular-nums',
+                letterSpacing: '-0.025em',
+              }}
+            >
+              {isNumeric ? (
+                <span data-anim="stat-value" data-value={s.value}>
+                  0
+                </span>
+              ) : (
+                s.value
+              )}
+              {s.unit && (
+                <span style={{ fontSize: '0.5em', fontWeight: 700, marginLeft: 3, color: C.inkMuted }}>
+                  {s.unit}
+                </span>
+              )}
+            </div>
+            <div
+              data-anim="stat-meta"
+              style={{ fontSize: 12, fontWeight: 700, color: C.ink, letterSpacing: '-0.005em' }}
+            >
+              {s.label}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// 좌측 인트로 완료 + 카드 fade-in 까지 끝난 뒤에야 slideshow 시작.
+// fade-in: scrollYProgress ≈ 0.115 ~ 0.169 (top-=0.85vh ~ 1.25vh, 컨테이너 = 7.4 viewport).
+// INTRO_FRAC 이후 구간에서 카드 transitions 진행.
+const INTRO_FRAC = 0.17
+
+// 카드/인디케이터 공통 timing — 인접 transition 안 겹치게 2*HOLD + TRANS = 1.0 (slot 단위)
+const HOLD_HALF_FRAC = 0.35
+const TRANS_FRAC = 0.3
+
+function CardStack({
+  triggerRef,
+  slideProgress,
+}: {
+  triggerRef: React.RefObject<HTMLDivElement | null>
+  slideProgress: MotionValue<number>
+}) {
+  const N = POINTS.length
+  const M = N + 1 // 카드 + quote
+  const stackRef = useRef<HTMLDivElement>(null)
+
+  // 좌측 인트로 (top 70% → +1.5vh) 끝난 직후 fade-in.
+  // GSAP scrub 으로 LeftIntro 와 같은 trigger 사용.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const stack = stackRef.current
+    const trigger = triggerRef.current
+    if (!stack || !trigger) return
+
+    const ctx = gsap.context(() => {
+      gsap.set(stack, { opacity: 0, y: 40 })
+      gsap.to(stack, {
+        opacity: 1,
+        y: 0,
+        ease: 'power2.out',
+        scrollTrigger: {
+          trigger,
+          // intro 완료 시점부터 시작 → 0.4 viewport 동안 fade-in
+          start: () => 'top top-=' + window.innerHeight * 0.85,
+          end: () => 'top top-=' + window.innerHeight * 1.25,
+          scrub: 0.6,
+          invalidateOnRefresh: true,
+        },
+      })
+    })
+
+    const refreshId = window.setTimeout(() => ScrollTrigger.refresh(), 100)
+    return () => {
+      window.clearTimeout(refreshId)
+      ctx.revert()
+    }
+  }, [triggerRef])
+
+  return (
+    <div
+      ref={stackRef}
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: 'clamp(380px, 56vh, 460px)',
+        willChange: 'transform, opacity',
+      }}
+    >
+      {POINTS.map((p, i) => (
+        <PointCard
+          key={p.k}
+          i={i}
+          m={M}
+          point={p}
+          scrollYProgress={slideProgress}
+        />
+      ))}
+
+      {/* 마지막 슬라이드 — 카드들 다 빠진 자리에 pull quote */}
+      <QuoteSlide i={N} m={M} scrollYProgress={slideProgress} />
+    </div>
+  )
+}
+
+function PointCard({
+  i,
+  m,
+  point,
+  scrollYProgress,
+}: {
+  i: number
+  m: number
+  point: { k: string; t: string; d: string }
+  scrollYProgress: MotionValue<number>
+}) {
+  const isScale = point.k === 'SCALE'
+  // hold 구간 포함 piecewise t — 카드가 화면에 "혼자" 머무르는 시간 확보.
+  // rel: scroll progress 와 카드 center 의 차.
+  //   < -HOLD_HALF-TRANS : invisible (t=-1, opacity 0)
+  //   ∈ [-HOLD_HALF-TRANS, -HOLD_HALF] : enter (t: -1 → 0)
+  //   ∈ [-HOLD_HALF, +HOLD_HALF] : hold (t=0, full opacity)
+  //   ∈ [+HOLD_HALF, +HOLD_HALF+TRANS] : exit (t: 0 → 1)
+  //   > +HOLD_HALF+TRANS : gone (t=1, opacity 0)
+  const t = useTransform(scrollYProgress, (p) => {
+    // 슬롯을 1/m 로 정의 — 마지막 quote 가 슬롯 끝에 도달한 뒤에도 추가 스크롤 동안
+    // 화면에 머물 수 있도록 한 슬롯 분량의 tail buffer 확보 (slideProgress=1 까지 hold).
+    const slot = 1 / m
+    const center = i * slot
+    // 인접 카드 transition 이 겹치지 않도록 2*HOLD_HALF + TRANS = slot 로 셋업.
+    // → 카드 i hold 동안 카드 i+1 은 완전 invisible. 진짜 "머무름" 구간 생김.
+    const HOLD_HALF = HOLD_HALF_FRAC * slot
+    const TRANS = TRANS_FRAC * slot
+    const rel = p - center
+    if (rel < -HOLD_HALF - TRANS) return -1
+    if (rel < -HOLD_HALF) return (rel + HOLD_HALF) / TRANS
+    if (rel <= HOLD_HALF) return 0
+    if (rel <= HOLD_HALF + TRANS) return (rel - HOLD_HALF) / TRANS
+    return 1
+  })
+
+  // preview 가 미리 보이지 않도록 t=-1 일 때 opacity 0 (이전 design 의 0.45 제거)
+  const opacity = useTransform(t, [-1.01, -1, 0, 1, 1.01], [0, 0, 1, 0, 0])
+  const x = useTransform(t, [-1, 0, 1], [90, 0, 0])
+  const y = useTransform(t, [-1, 0, 1], [80, 0, -120])
+  const scale = useTransform(t, [-1, 0, 1], [0.78, 1, 0.88])
+  const zIndex = useTransform(t, (v) => Math.round(100 - Math.abs(v) * 20))
+  const filter = useTransform(t, [-1, 0], ['blur(4px)', 'blur(0px)'])
+  const indexLabel = String(i + 1).padStart(2, '0')
+
+  return (
+    <motion.article
+      style={{
+        position: 'absolute',
+        inset: 0,
+        opacity,
+        x,
+        y,
+        scale,
+        zIndex,
+        filter,
+        background: C.bgWhite,
+        borderRadius: 28,
+        border: `1px solid ${C.cardBorder}`,
+        boxShadow: '0 24px 60px rgba(10, 18, 36, 0.10)',
+        padding: 'clamp(28px, 3vw, 44px)',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        gap: 24,
+        willChange: 'transform, opacity',
+        transformOrigin: 'center bottom',
+      }}
+    >
+      {/* 상단 — 큰 인덱스 + 키워드 */}
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16 }}>
+        <div
+          style={{
+            fontFamily: FONT_MONO,
+            fontSize: 11,
+            letterSpacing: '0.24em',
+            color: C.nexonBlue,
+            fontWeight: 800,
+          }}
+        >
+          POINT · {point.k}
+        </div>
+        <div
+          style={{
+            fontFamily: FONT_DISPLAY,
+            fontSize: 'clamp(56px, 7vw, 88px)',
+            fontWeight: 900,
+            lineHeight: 0.85,
+            color: C.nexonBlue,
+            letterSpacing: '-0.04em',
+            fontVariantNumeric: 'tabular-nums',
+            opacity: 0.18,
+            marginTop: -6,
+          }}
+        >
+          {indexLabel}
+        </div>
+      </header>
+
+      {/* 본문 — 큰 헤드라인 + 보조 설명 */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+        <h3
+          style={{
+            margin: 0,
+            fontFamily: FONT_DISPLAY,
+            fontSize: 'clamp(28px, 3.2vw, 42px)',
+            fontWeight: 800,
+            lineHeight: 1.18,
+            letterSpacing: '-0.025em',
+            color: C.ink,
+            wordBreak: 'keep-all',
+          }}
+        >
+          {point.t}
+        </h3>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: FONT_BODY,
+            fontSize: 'clamp(15px, 1.3vw, 18px)',
+            lineHeight: 1.55,
+            color: C.inkSoft,
+            fontWeight: 500,
+            wordBreak: 'keep-all',
+            maxWidth: 540,
+          }}
+        >
+          {point.d}
+        </p>
+        {isScale && (
+          <div style={{ marginTop: 4 }}>
+            <LiveServersMarquee compact />
+          </div>
+        )}
+      </div>
+
+    </motion.article>
+  )
+}
+
+function QuoteSlide({
+  i,
+  m,
+  scrollYProgress,
+}: {
+  i: number
+  m: number
+  scrollYProgress: MotionValue<number>
+}) {
+  // PointCard 와 같은 piecewise t — preview 미노출 + hold 구간 확보. exit 없음.
+  const t = useTransform(scrollYProgress, (p) => {
+    // 슬롯을 1/m 로 정의 — 마지막 quote 가 슬롯 끝에 도달한 뒤에도 추가 스크롤 동안
+    // 화면에 머물 수 있도록 한 슬롯 분량의 tail buffer 확보 (slideProgress=1 까지 hold).
+    const slot = 1 / m
+    const center = i * slot
+    // 인접 카드 transition 이 겹치지 않도록 2*HOLD_HALF + TRANS = slot 로 셋업.
+    // → 카드 i hold 동안 카드 i+1 은 완전 invisible. 진짜 "머무름" 구간 생김.
+    const HOLD_HALF = HOLD_HALF_FRAC * slot
+    const TRANS = TRANS_FRAC * slot
+    const rel = p - center
+    if (rel < -HOLD_HALF - TRANS) return -1
+    if (rel < -HOLD_HALF) return (rel + HOLD_HALF) / TRANS
+    return 0
+  })
+  const opacity = useTransform(t, [-1.01, -1, 0], [0, 0, 1])
+  const y = useTransform(t, [-1, 0], [120, 0])
+  const scale = useTransform(t, [-1, 0], [0.85, 1])
+  const zIndex = useTransform(t, (v) => Math.round(100 - Math.abs(v) * 20))
+
+  return (
+    <motion.div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        opacity,
+        y,
+        scale,
+        zIndex,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        padding: 'clamp(28px, 3vw, 44px) clamp(12px, 1.5vw, 24px)',
+        willChange: 'transform, opacity',
+      }}
+    >
+      <div
+        style={{
+          fontFamily: FONT_MONO,
+          fontSize: 11,
+          letterSpacing: '0.24em',
+          color: C.nexonBlue,
+          fontWeight: 800,
+          marginBottom: 24,
+        }}
+      >
+        SO — 결론
+      </div>
+
+      <blockquote
+        style={{
+          margin: 0,
+          paddingTop: 28,
+          borderTop: `2px solid ${C.ink}`,
+        }}
+      >
+        <p
+          style={{
+            margin: 0,
+            fontFamily: FONT_DISPLAY,
+            fontSize: 'clamp(26px, 3vw, 38px)',
+            lineHeight: 1.32,
+            fontWeight: 800,
+            letterSpacing: '-0.025em',
+            color: C.ink,
+            wordBreak: 'keep-all',
+          }}
+        >
+          이 직접 만든 경험을 메이플AX실의{' '}
+          <span style={{ color: C.nexonBlue }}>제작 도구 프론트엔드</span>로
+          <br />
+          그대로 이어 가고 싶습니다.
+        </p>
+      </blockquote>
+    </motion.div>
+  )
+}
+
+
+function ProgressBar({
+  scrollYProgress,
+  slideProgress,
+  count,
+  containerRef,
+}: {
+  scrollYProgress: MotionValue<number>
+  slideProgress: MotionValue<number>
+  count: number
+  containerRef: React.RefObject<HTMLDivElement | null>
+}) {
+  const goTo = (i: number) => {
+    if (typeof window === 'undefined') return
+    const container = containerRef.current
+    if (!container) return
+    // 카드 i center = i / count (slot = 1/count, center at i*slot).
+    // scrollYProgress 로 변환: INTRO_FRAC + slideTarget * (1 - INTRO_FRAC)
+    const slideTarget = i / count
+    const sypTarget = INTRO_FRAC + slideTarget * (1 - INTRO_FRAC)
+    const targetY = container.offsetTop + sypTarget * (container.offsetHeight - window.innerHeight)
+    const lenis = (window as { __lenis?: { scrollTo: (y: number, opts?: object) => void } }).__lenis
+    if (lenis?.scrollTo) {
+      lenis.scrollTo(targetY, { duration: 1.4 })
+    } else {
+      window.scrollTo({ top: targetY, behavior: 'smooth' })
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 'clamp(32px, 5vh, 56px)',
+        left: 'clamp(40px, 6vw, 120px)',
+        right: 'clamp(40px, 6vw, 120px)',
+      }}
+    >
+      {/* 연속 progress bar — 첫 스크롤부터 즉각 반응 */}
+      <div
+        style={{
+          position: 'relative',
+          height: 4,
+          background: 'rgba(10,18,36,0.08)',
+          borderRadius: 2,
+          overflow: 'visible',
+        }}
+      >
+        {/* fill — 핀 engage 즉시 0 부터 채워짐 (scrollYProgress 기준) */}
+        <motion.div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            background: C.nexonBlue,
+            borderRadius: 2,
+            transformOrigin: 'left center',
+            scaleX: scrollYProgress,
+          }}
+        />
+
+        {/* 클릭 가능한 tick — 각 카드 center 위치(scrollYProgress 좌표)에 배치 */}
+        {Array.from({ length: count }).map((_, i) => (
+          <IndicatorTick
+            key={i}
+            index={i}
+            count={count}
+            slideProgress={slideProgress}
+            onClick={() => goTo(i)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function IndicatorTick({
+  index,
+  count,
+  slideProgress,
+  onClick,
+}: {
+  index: number
+  count: number
+  slideProgress: MotionValue<number>
+  onClick: () => void
+}) {
+  // 카드 i 가 가까울수록(=현재 active) tick 강조
+  const distance = useTransform(slideProgress, (p) => Math.abs(p * count - index))
+  const dotScale = useTransform(distance, [0, 0.5, 1.2], [1.6, 1.0, 0.8])
+  const dotOpacity = useTransform(distance, [0, 0.5, 1.2], [1, 0.7, 0.45])
+  // tick 가로 위치 — scrollYProgress 좌표계 (bar 와 일치).
+  // 카드 i center 의 scrollYProgress = INTRO_FRAC + (i/count) * (1 - INTRO_FRAC)
+  const leftPercent = (INTRO_FRAC + (index / count) * (1 - INTRO_FRAC)) * 100
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Slide ${index + 1} 으로 이동`}
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: `${leftPercent}%`,
+        transform: 'translate(-50%, -50%)',
+        width: 18,
+        height: 18,
+        background: 'transparent',
+        border: 'none',
+        padding: 0,
+        cursor: 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <motion.div
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: '50%',
+          background: C.bgWhite,
+          border: `2px solid ${C.nexonBlue}`,
+          scale: dotScale,
+          opacity: dotOpacity,
+        }}
+      />
+    </button>
+  )
+}
+
+function StickyLabel({ ch, no, kicker }: { ch: string; no: string; kicker: string }) {
+  const labelStyle: CSSProperties = {
+    fontFamily: FONT_BODY,
+    fontSize: 11,
+    fontWeight: 800,
+    letterSpacing: '0.22em',
+    textTransform: 'uppercase',
+  }
+  return (
+    <div>
+      <div style={{ ...labelStyle, color: C.nexonBlue, marginBottom: 4 }}>
+        {ch} · {no}
+      </div>
+      <div style={{ ...labelStyle, color: C.inkMuted }}>{kicker}</div>
+    </div>
+  )
+}
+
+/** ?reveal=off — 정적 캡처용 fallback. 슬라이드 비활성, 모든 카드 그리드로 표시 */
+function Ch1Static() {
+  return (
+    <section id="about" style={{ background: C.bgWhite, padding: 'clamp(72px, 12vw, 110px) clamp(20px, 6vw, 120px)' }}>
+      <div style={{ maxWidth: 1280, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: 'clamp(28px, 5vw, 48px)' }}>
+        <StickyLabel ch="CH 1" no="01—02" kicker="WHO · ABOUT" />
+        <h2 style={{ fontFamily: FONT_DISPLAY, fontSize: 'clamp(28px, 7vw, 44px)', fontWeight: 800, margin: 0, lineHeight: 1.18, wordBreak: 'keep-all' }}>저는 이런 사람입니다</h2>
+        <StatStripe />
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+            gap: 24,
+          }}
+        >
+          {POINTS.map((p) => (
+            <div
+              key={p.k}
+              style={{
+                padding: 24,
+                border: `1px solid ${C.cardBorder}`,
+                borderRadius: 18,
+                background: C.bgWhite,
+              }}
+            >
+              <div style={{ fontSize: 11, letterSpacing: '0.22em', color: C.nexonBlue, fontWeight: 800 }}>
+                {p.k}
+              </div>
+              <div style={{ fontFamily: FONT_DISPLAY, fontSize: 20, fontWeight: 700, marginTop: 8 }}>
+                {p.t}
+              </div>
+              <div style={{ fontSize: 14, color: C.inkSoft, marginTop: 6 }}>{p.d}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/sections/Ch2WhatFE.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/sections/Ch2WhatFE.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useRef, useState } from 'react'
+import { gsap } from 'gsap'
+import { ScrollTrigger } from 'gsap/ScrollTrigger'
+import SectionShell from '../shared/SectionShell'
+import ArchitectureDiagram from '../shared/ArchitectureDiagram'
+import { C, FONT_MONO, FONT_BODY, FONT_DISPLAY } from '../shared/colors'
+import { ARCHITECTURE } from '../content/frontend'
+
+gsap.registerPlugin(ScrollTrigger)
+
+/**
+ * CH 2 — WHAT
+ * 02 ARCHITECTURE : 다이어그램 + 클릭 evidence
+ * 03 OTHER       : 다이어그램 밖 인프라 — 매거진 풍 stagger reveal 스택 카드
+ */
+export default function Ch2What() {
+  return (
+    <>
+      <ArchitectureDiagram steps={ARCHITECTURE.steps} title={ARCHITECTURE.title} />
+
+      <SectionShell
+        id="tech"
+        ch="CH 2"
+        no="03"
+        kicker="STACK · 다이어그램 밖 나머지 도구"
+        title="이 화면을 굴리는 나머지 스택"
+        variant="aside"
+        background={C.bgSoft}
+      >
+        <StackList items={STACK} />
+      </SectionShell>
+    </>
+  )
+}
+
+type StackItem = {
+  category: string  // 카테고리 (kicker)
+  headline: string  // 한 줄 요약 (큰 글자)
+  chips: string[]   // 기술 chip 묶음
+}
+
+const STACK: StackItem[] = [
+  {
+    category: 'FRONTEND · 프레임워크',
+    headline: 'React 19 + Vite + TypeScript + Tailwind — 이 페이지의 뼈대',
+    chips: ['React 19', 'Vite', 'TypeScript', 'Tailwind'],
+  },
+  {
+    category: 'FRONTEND · 스크롤·모션',
+    headline: 'GSAP ScrollTrigger + Lenis + framer-motion 을 한 루프로',
+    chips: ['GSAP', 'ScrollTrigger', 'Lenis', 'framer-motion'],
+  },
+  {
+    category: 'FRONTEND · 3D·그래픽스',
+    headline: 'three.js 배경 3종 + WebGL 셰이더 (섹션별 교체)',
+    chips: ['three.js', 'WebGL', 'Ballpit', 'Aurora', 'Lightning'],
+  },
+  {
+    category: 'NATIVE · GPU 터미널',
+    headline: 'kasaterm — Rust 로 직접 짠 GPU 셀 렌더러',
+    chips: ['Rust', 'wgpu', 'winit', 'vt100'],
+  },
+  {
+    category: 'NATIVE · 렌더 최적화',
+    headline: 'damage tracking + P3/Bradford 색 파이프라인 (1.25GB→113MB)',
+    chips: ['damage tracking', 'P3', 'Bradford', 'GPU readback'],
+  },
+  {
+    category: 'AI · 모델 연동',
+    headline: 'Anthropic Managed Agent SSE 스트리밍 챗봇 (이 페이지 하단)',
+    chips: ['Managed Agents', 'SSE', 'streaming'],
+  },
+  {
+    category: 'AI · 개발 하네스',
+    headline: 'MCP + hook + 서브에이전트 + LiteLLM 멀티모델 스위칭',
+    chips: ['MCP', 'hook', '서브에이전트', 'LiteLLM'],
+  },
+  {
+    category: 'INFRA · 배포',
+    headline: 'PWA + Cloudflare 캐시 + GCP · Docker',
+    chips: ['PWA', 'Cloudflare', 'GCP', 'Docker'],
+  },
+]
+
+function StackList({ items }: { items: StackItem[] }) {
+  const [expanded, setExpanded] = useState(false)
+  const wrapRef = useRef<HTMLOListElement>(null)
+
+  useEffect(() => {
+    if (!expanded) return
+    const el = wrapRef.current
+    if (!el) return
+    const rows = el.querySelectorAll('.stack-row')
+    const ctx = gsap.context(() => {
+      gsap.fromTo(
+        rows,
+        { opacity: 0, y: 28 },
+        {
+          opacity: 1,
+          y: 0,
+          duration: 0.5,
+          ease: 'power3.out',
+          stagger: 0.05,
+        },
+      )
+    }, el)
+    return () => ctx.revert()
+  }, [expanded])
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        style={{
+          fontFamily: FONT_MONO,
+          fontSize: 12,
+          fontWeight: 700,
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: C.nexonBlue,
+          background: 'transparent',
+          border: `1px solid ${C.cardBorder}`,
+          padding: '14px 22px',
+          borderRadius: 999,
+          cursor: 'pointer',
+          transition: 'background 200ms ease, border-color 200ms ease',
+          alignSelf: 'flex-start',
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = C.bgWhite
+          e.currentTarget.style.borderColor = C.nexonBlue
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = 'transparent'
+          e.currentTarget.style.borderColor = C.cardBorder
+        }}
+      >
+        + 운영 인프라 {items.length}개 펼쳐 보기
+      </button>
+    )
+  }
+
+  return (
+    <ol
+      ref={wrapRef}
+      style={{
+        listStyle: 'none',
+        margin: 0,
+        padding: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        borderTop: `1px solid ${C.cardBorder}`,
+      }}
+    >
+      {items.map((item, i) => (
+        <StackRow key={item.category} item={item} index={i} />
+      ))}
+    </ol>
+  )
+}
+
+function StackRow({ item, index }: { item: StackItem; index: number }) {
+  return (
+    <li
+      className="stack-row"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'minmax(56px, 84px) minmax(0, 1fr)',
+        gap: 'clamp(20px, 3vw, 40px)',
+        padding: '24px 0',
+        borderBottom: `1px solid ${C.cardBorder}`,
+        position: 'relative',
+        cursor: 'default',
+      }}
+      onMouseEnter={(e) => {
+        const num = e.currentTarget.querySelector<HTMLElement>('.stack-num')
+        const head = e.currentTarget.querySelector<HTMLElement>('.stack-head')
+        if (num) num.style.color = C.nexonBlue
+        if (head) head.style.color = C.nexonBlue
+      }}
+      onMouseLeave={(e) => {
+        const num = e.currentTarget.querySelector<HTMLElement>('.stack-num')
+        const head = e.currentTarget.querySelector<HTMLElement>('.stack-head')
+        if (num) num.style.color = C.cardBorder
+        if (head) head.style.color = C.ink
+      }}
+    >
+      <span
+        className="stack-num"
+        style={{
+          fontFamily: FONT_DISPLAY,
+          fontSize: 'clamp(28px, 3.4vw, 44px)',
+          fontWeight: 800,
+          lineHeight: 1,
+          color: C.cardBorder,
+          letterSpacing: '-0.04em',
+          transition: 'color 220ms ease',
+        }}
+      >
+        {String(index + 1).padStart(2, '0')}
+      </span>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div
+          style={{
+            fontFamily: FONT_MONO,
+            fontSize: 11,
+            fontWeight: 800,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: C.nexonBlue,
+          }}
+        >
+          {item.category}
+        </div>
+        <div
+          className="stack-head"
+          style={{
+            fontFamily: FONT_BODY,
+            fontSize: 'clamp(17px, 1.6vw, 20px)',
+            fontWeight: 600,
+            lineHeight: 1.45,
+            color: C.ink,
+            letterSpacing: '-0.01em',
+            wordBreak: 'keep-all',
+            transition: 'color 220ms ease',
+          }}
+        >
+          {item.headline}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 6,
+            marginTop: 4,
+          }}
+        >
+          {item.chips.map((chip) => (
+            <span
+              key={chip}
+              style={{
+                fontFamily: FONT_MONO,
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: '0.04em',
+                color: C.inkSoft,
+                background: C.bgWhite,
+                border: `1px solid ${C.cardBorder}`,
+                padding: '4px 10px',
+                borderRadius: 999,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {chip}
+            </span>
+          ))}
+        </div>
+      </div>
+    </li>
+  )
+}

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/sections/Ch3WhyFE.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/sections/Ch3WhyFE.tsx
@@ -1,0 +1,34 @@
+import JdScrollytelling from '../shared/JdScrollytelling'
+import EligibilityScrollytelling from '../shared/EligibilityScrollytelling'
+import PreferredMarquee from '../shared/PreferredMarquee'
+import CasesScrollStack from '../shared/CasesScrollStack'
+import { JD_MATCHES, CASES, CHARACTER, GAMES, ELIGIBILITY } from '../content/frontend'
+
+/**
+ * CH 3 — WHY
+ * 04 JD MATCH (4)         : sticky scrollytelling — VaultDial + ContentDial flat stack
+ * 05 ELIGIBILITY          : sticky scrollytelling — 캐릭터 도킹 + 좌측 텍스트 dial
+ * 06 PREFERRED            : dual marquee (좌/우 반대 방향, scroll velocity 반응)
+ * 07 TROUBLESHOOTING (6)  : tabs — Case pills + Row tabs (4 row 컬러)
+ *
+ * COLLAB 콘텐츠는 JD 4번 evidence 에 이미 들어가 있어 별도 섹션 제거.
+ */
+export default function Ch3Why() {
+  return (
+    <>
+      {/* 04 — 주요 업무 매칭 */}
+      <div id="jdmatch">
+        <JdScrollytelling items={JD_MATCHES} />
+      </div>
+
+      {/* 05 — 지원 자격 */}
+      <EligibilityScrollytelling eligibility={ELIGIBILITY} character={CHARACTER} />
+
+      {/* 06 — 우대 사항 */}
+      <PreferredMarquee games={GAMES} />
+
+      {/* 07 — 트러블슈팅 (scroll-stack) */}
+      <CasesScrollStack items={CASES} />
+    </>
+  )
+}

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/sections/Ch4ReachFE.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/sections/Ch4ReachFE.tsx
@@ -1,0 +1,28 @@
+import CtaSection from '../shared/CtaSection'
+import Footer from '../shared/Footer'
+import { CONTACT } from '../content/frontend'
+
+/**
+ * CH 4 — REACH
+ * CTA + Footer
+ */
+export default function Ch4Reach() {
+  return (
+    <>
+      <div id="contact">
+        <CtaSection
+          kicker="LET'S TALK"
+          headline={`라이브로 만들어 본 사람이\n메이플AX실 제작 도구에 합류하면 좋겠습니다`}
+          sub="Rust GPU 터미널부터 지금 이 페이지까지, 디자인과 프론트엔드 구현을 한 사람이 해 왔습니다. 브라우저에서 시각 요소를 편집하고 실시간으로 협업하는 생성형 AI 제작 도구 — 이미 만들어 본 그 방향으로 합류하고 싶습니다."
+          items={[
+            { label: 'GitHub · 2rami', href: CONTACT.github, primary: true, external: true },
+            { label: 'Live · debimarlene.com', href: CONTACT.domain },
+            { label: '이 페이지가 곧 포트폴리오', href: 'https://debimarlene.com/portfolio/nexon/frontend' },
+            { label: `Email · ${CONTACT.email}`, href: `mailto:${CONTACT.email}` },
+          ]}
+        />
+      </div>
+      <Footer email={CONTACT.email} github={CONTACT.github} domain={CONTACT.domain} edu={CONTACT.edu} />
+    </>
+  )
+}

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/shared/CornerLabels.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/shared/CornerLabels.tsx
@@ -8,9 +8,11 @@ import useIsMobile from './useIsMobile'
  * 모바일에선 정체성 라벨만 작게, CTA(GO TO BOT)는 본문 우선이라 숨김.
  */
 export default function CornerLabels({
+  label = 'NEXON · LLM EVAL',
   ctaLabel = 'GO TO PROJECT',
   ctaHref = 'https://github.com/2rami/debi-marlene',
 }: {
+  label?: string
   ctaLabel?: string
   ctaHref?: string
 }) {
@@ -41,7 +43,7 @@ export default function CornerLabels({
             textTransform: 'uppercase',
           }}
         >
-          NEXON · LLM EVAL
+          {label}
         </span>
       </div>
 

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/shared/MapleChatbot.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/shared/MapleChatbot.tsx
@@ -121,8 +121,12 @@ function fakeReply(prompt: string): string {
 
 export default function MapleChatbot({
   hash = DEFAULT_HASH,
+  intro = '안녕하세요! 저는 디지털 클론 양건호입니다. 저에 대해 궁금한 점이 있으신가요?',
+  roam = true,
 }: {
   hash?: string
+  intro?: string
+  roam?: boolean
 }) {
   const [open, setOpen] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
@@ -130,7 +134,7 @@ export default function MapleChatbot({
     {
       id: 'init',
       role: 'agent',
-      text: '안녕하세요! 저는 디지털 클론 양건호입니다. 저에 대해 궁금한 점이 있으신가요?',
+      text: intro,
     },
   ])
   const [input, setInput] = useState('')
@@ -255,9 +259,21 @@ export default function MapleChatbot({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
-  // 테두리 걷기 로직 (bottom edge) — 도킹 중엔 정지
+  // 슬라이드덱 등 고정 뷰용 — roam=false 면 배회 없이 우하단 코너에 고정.
+  // 배회 useEffect 가 early-return 되어 초기 배치를 안 하므로 여기서 직접 세팅.
   useEffect(() => {
-    if (open || isDragging || reduced || dockEl) return;
+    if (roam || open || isDragging || dockEl) return
+    const x = viewport.w - MARGIN - CHAR_SIZE
+    const y = viewport.h - MARGIN - CHAR_SIZE
+    controls.set({ x, y, scale: 1, opacity: 1 })
+    currentXRef.current = x
+    lastDragPosRef.current = { x, y }
+    firstRunRef.current = false
+  }, [roam, open, isDragging, dockEl, viewport.w, viewport.h, controls])
+
+  // 테두리 걷기 로직 (bottom edge) — 도킹 중엔 정지. roam=false 면 배회 안 함.
+  useEffect(() => {
+    if (open || isDragging || reduced || dockEl || !roam) return;
 
     let cancelled = false;
     
@@ -752,6 +768,30 @@ export default function MapleChatbot({
     },
     [loading]
   )
+
+  // 섹션↔캐릭터 브릿지 — 슬라이드덱은 window 스크롤이 없어 말풍선 자동 전환이 죽는다.
+  // 외부(PageFrontendDeck)가 현재 섹션 대사/질문을 이벤트로 주입한다.
+  useEffect(() => {
+    const onSay = (e: Event) => {
+      const text = (e as CustomEvent).detail?.text
+      if (!text) return
+      keyboardHintRef.current = false
+      if (dockEl) return // 도킹 중엔 dock 전용 버블 유지
+      setBubbleText(text)
+    }
+    const onAsk = (e: Event) => {
+      const prompt = (e as CustomEvent).detail?.prompt
+      if (!prompt) return
+      setOpen(true)
+      send(prompt)
+    }
+    window.addEventListener('nexon:char-say', onSay)
+    window.addEventListener('nexon:char-ask', onAsk)
+    return () => {
+      window.removeEventListener('nexon:char-say', onSay)
+      window.removeEventListener('nexon:char-ask', onAsk)
+    }
+  }, [send, dockEl])
 
   function onKey(e: KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/shared/NexonGateFE.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/shared/NexonGateFE.tsx
@@ -1,0 +1,349 @@
+import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+import { C, FONT_BODY, FONT_DISPLAY, GATE_COLORS, FONT_MONO } from './colors'
+import Button from './Button'
+import Aurora from '../../../components/common/Aurora'
+import FloatingShapes from './FloatingShapes'
+import { useRevealOff } from './useRevealOff'
+import useIsMobile from './useIsMobile'
+
+import { HERO, STATS } from '../content/frontend'
+
+/**
+ * CH 0 — GATE → HERO
+ *
+ * 마운트 즉시 자동 재생. phase 3단계로 명확히 분리:
+ *   - assemble (0 ~ 2.0s): facets 회전·스케일 풀리며 합체. blur 없음
+ *   - hold     (2.0 ~ 3.0s): 완전 합체된 로고 정지. blur 없음
+ *   - exit     (3.0 ~ 4.0s): scale 축소 + blur + fade out
+ *
+ * Hero content 는 hold 끝물부터 stagger 등장 (exit 과 살짝 겹침)
+ *
+ * ?reveal=off 이면 모든 단계 instant (Figma 캡처용).
+ */
+
+const ASSEMBLE_DUR = 2.0
+const ASSEMBLE_EASE = [0.16, 1, 0.3, 1] as const
+const HOLD_DUR = 1.0
+const EXIT_DUR = 1.0
+const HERO_DELAY = ASSEMBLE_DUR + HOLD_DUR - 0.1 // 2.9s — exit 직전부터 등장
+const HERO_STAGGER = 0.12
+
+type Phase = 'assemble' | 'hold' | 'exit'
+
+export default function NexonGate() {
+  const revealOff = useRevealOff()
+  const isMobile = useIsMobile()
+  const [phase, setPhase] = useState<Phase>(revealOff ? 'exit' : 'assemble')
+
+  useEffect(() => {
+    if (revealOff) return
+    const toHold = window.setTimeout(() => setPhase('hold'), ASSEMBLE_DUR * 1000)
+    const toExit = window.setTimeout(() => setPhase('exit'), (ASSEMBLE_DUR + HOLD_DUR) * 1000)
+    return () => {
+      window.clearTimeout(toHold)
+      window.clearTimeout(toExit)
+    }
+  }, [revealOff])
+
+  const T = revealOff ? 0 : 1
+
+  return (
+    <section
+      id="hero"
+      style={{
+        position: 'relative',
+        minHeight: '100vh',
+        background: C.bgWhite,
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          position: 'relative',
+          minHeight: '100vh',
+          height: isMobile ? 'auto' : '100vh',
+          padding: isMobile ? '24px 0' : 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {/* 배경 */}
+        <div style={{ position: 'absolute', inset: 0 }}>
+          <div className="absolute inset-0 opacity-20 mix-blend-screen pointer-events-none">
+            <Aurora colorStops={[C.nexonBlue, C.nexonLightBlue, C.nexonBlueAlt]} amplitude={0.9} speed={0.4} />
+          </div>
+          <div style={{ position: 'absolute', inset: 0, opacity: 0.3 }}>
+            <FloatingShapes />
+          </div>
+        </div>
+
+        {/* 로고 컨테이너 — phase 'exit' 일 때만 축소 + blur + fade */}
+        <motion.div
+          initial={{ scale: 1, opacity: 1, filter: 'blur(0px)' }}
+          animate={
+            phase === 'exit'
+              ? { scale: 0.12, opacity: 0, filter: 'blur(14px)' }
+              : { scale: 1, opacity: 1, filter: 'blur(0px)' }
+          }
+          transition={{
+            duration: phase === 'exit' ? EXIT_DUR * T : 0,
+            ease: ASSEMBLE_EASE,
+          }}
+          style={{ zIndex: 10, pointerEvents: 'none', position: 'absolute' }}
+        >
+          <svg viewBox="0 0 493.85 480.16" width={isMobile ? 'min(72vw, 320px)' : 'min(60vw, 540px)'}>
+            <Facet
+              fill={GATE_COLORS.blue}
+              points="128.74 196.98 128.74 286.79 247.95 223.4"
+              fromX={-460}
+              fromY={260}
+              fromRotate={-32}
+              fromScale={1.6}
+              T={T}
+            />
+            <Facet
+              fill={GATE_COLORS.navy}
+              points="247.95 52.49 128.74 115.88 128.74 196.98 247.95 223.4"
+              fromX={-120}
+              fromY={-420}
+              fromRotate={28}
+              fromScale={1.5}
+              T={T}
+            />
+            <Facet
+              fill={GATE_COLORS.lime}
+              points="247.95 223.4 128.74 286.79 276.58 319.58 395.79 256.18"
+              fromX={520}
+              fromY={200}
+              fromRotate={-22}
+              fromScale={1.7}
+              T={T}
+            />
+            {/* NEXON 글자 — 합체 후반에 페이드 */}
+            <motion.g
+              fill={GATE_COLORS.black}
+              initial={{ opacity: 0, y: 30 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{
+                duration: 0.7 * T,
+                delay: ASSEMBLE_DUR * 0.6 * T,
+                ease: ASSEMBLE_EASE,
+              }}
+            >
+              <polygon points="193.73 414.2 145.75 414.2 145.75 402.01 193.73 402.01 193.73 388.45 145.75 388.45 145.75 377.56 193.73 377.56 193.73 364.07 128.74 364.07 128.74 427.67 193.73 427.67 193.73 414.2" />
+              <polygon points="400.46 389.22 440.75 427.67 453.58 427.67 453.58 364.07 436.57 364.07 436.57 402.53 396.28 364.07 383.45 364.07 383.45 427.67 400.46 427.67 400.46 389.22" />
+              <path d="M365.12,364.07h-70.14v63.59h70.14v-63.59ZM348.12,414.2h-36.12v-36.65h36.12v36.65Z" />
+              <polygon points="57.28 389.22 97.58 427.67 110.41 427.67 110.41 364.07 93.4 364.07 93.4 402.53 53.1 364.07 40.26 364.07 40.26 427.67 57.28 427.67 57.28 389.22" />
+              <polygon points="244.4 408.03 261.82 427.67 283.31 427.67 255.14 395.9 283.38 364.07 261.86 364.07 244.4 383.79 226.93 364.07 205.43 364.07 233.64 395.9 205.49 427.67 226.99 427.67 244.4 408.03" />
+            </motion.g>
+          </svg>
+        </motion.div>
+
+        {/* Hero content */}
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            padding: isMobile ? '80px 22px 32px' : '60px clamp(48px, 8vw, 120px) 40px',
+            display: 'flex',
+            alignItems: 'center',
+            position: 'relative',
+            zIndex: 5,
+          }}
+        >
+          <div
+            style={{
+              maxWidth: 1480,
+              margin: '0 auto',
+              display: 'grid',
+              gridTemplateColumns: isMobile ? '1fr' : 'minmax(0, 1.6fr) minmax(280px, 1fr)',
+              gap: isMobile ? 36 : 64,
+              alignItems: 'start',
+              width: '100%',
+            }}
+          >
+            <div>
+              <HeroIn delayIndex={0} fromX={-80} T={T}>
+                <div
+                  style={{
+                    display: 'inline-block',
+                    padding: '6px 14px',
+                    color: C.nexonBlue,
+                    border: `1px solid ${C.nexonBlue}`,
+                    borderRadius: 9999,
+                    fontSize: 11,
+                    fontWeight: 700,
+                    letterSpacing: '0.18em',
+                    textTransform: 'uppercase',
+                    marginBottom: 32,
+                  }}
+                >
+                  {HERO.badge}
+                </div>
+              </HeroIn>
+
+              <h1
+                style={{
+                  fontFamily: FONT_DISPLAY,
+                  fontSize: 'clamp(36px, 5.5vw, 76px)',
+                  fontWeight: 700,
+                  lineHeight: 1.08,
+                  letterSpacing: '-0.04em',
+                  color: C.ink,
+                  margin: '0 0 24px',
+                  wordBreak: 'keep-all',
+                }}
+              >
+                {HERO.titleLines.map((line, i) => {
+                  const idx = line.indexOf(HERO.highlightWord)
+                  const before = idx >= 0 ? line.slice(0, idx) : line
+                  const after = idx >= 0 ? line.slice(idx + HERO.highlightWord.length) : ''
+                  return (
+                    <HeroIn key={i} delayIndex={1 + i} fromX={-80} T={T}>
+                      <span style={{ display: 'block' }}>
+                        {before}
+                        {idx >= 0 && (
+                          <span style={{ color: C.nexonBlue }}>{HERO.highlightWord}</span>
+                        )}
+                        {after}
+                      </span>
+                    </HeroIn>
+                  )
+                })}
+              </h1>
+
+              <HeroIn delayIndex={4} fromX={-80} T={T}>
+                <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 28 }}>
+                  {HERO.ctas.map((cta) => (
+                    <Button
+                      key={cta.label}
+                      label={cta.label}
+                      href={cta.href}
+                      variant={cta.primary ? 'primary' : 'outline'}
+                      external={cta.href.startsWith('http') || cta.href.endsWith('.pdf')}
+                    />
+                  ))}
+                </div>
+              </HeroIn>
+
+              <HeroIn delayIndex={5} fromX={80} T={T}>
+                <div
+                  style={{
+                    fontSize: 'clamp(15px, 1.3vw, 19px)',
+                    fontWeight: 500,
+                    lineHeight: 1.7,
+                    color: C.inkSoft,
+                    maxWidth: 720,
+                    minHeight: '4em',
+                    fontFamily: FONT_BODY,
+                  }}
+                >
+                  {HERO.subtitle}
+                </div>
+              </HeroIn>
+            </div>
+
+            <HeroIn delayIndex={3} fromX={80} T={T}>
+              <div style={{ padding: '32px 0 0', borderTop: `2px solid ${C.ink}` }}>
+                <div style={{ fontFamily: FONT_MONO, fontSize: 10, letterSpacing: '0.2em', color: C.nexonBlue, fontWeight: 700, marginBottom: 24 }}>
+                  INFO
+                </div>
+                <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                  <tbody>
+                    {HERO.meta.map((row) => (
+                      <tr key={row.label} style={{ borderBottom: `1px solid ${C.cardBorder}` }}>
+                        <td style={{ fontFamily: FONT_MONO, fontSize: 10.5, letterSpacing: '0.16em', color: C.inkMuted, fontWeight: 700, padding: '14px 0', width: 100, verticalAlign: 'top' }}>
+                          {row.label}
+                        </td>
+                        <td style={{ fontSize: 14.5, color: C.ink, fontWeight: 600, padding: '14px 0', lineHeight: 1.45 }}>
+                          {row.value}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+
+                <div style={{ marginTop: 32, paddingTop: 24, borderTop: `1px dashed ${C.cardBorder}`, display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 24 }}>
+                  {STATS.map((s) => (
+                    <div key={s.label}>
+                      <div style={{ fontSize: 28, fontWeight: 800, lineHeight: 1, letterSpacing: '-0.025em', color: C.ink }}>
+                        {s.value}
+                        {s.unit && (
+                          <span style={{ fontSize: '0.45em', fontWeight: 700, marginLeft: 3, color: C.inkMuted }}>
+                            {s.unit}
+                          </span>
+                        )}
+                      </div>
+                      <div style={{ fontFamily: FONT_MONO, fontSize: 10, color: C.inkMuted, letterSpacing: '0.08em', fontWeight: 700, marginTop: 6 }}>
+                        {s.label}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </HeroIn>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────
+
+function Facet({
+  fill,
+  points,
+  fromX,
+  fromY,
+  fromRotate,
+  fromScale,
+  T,
+}: {
+  fill: string
+  points: string
+  fromX: number
+  fromY: number
+  fromRotate: number
+  fromScale: number
+  T: number
+}) {
+  return (
+    <motion.g
+      initial={{ x: fromX, y: fromY, rotate: fromRotate, scale: fromScale, opacity: 0 }}
+      animate={{ x: 0, y: 0, rotate: 0, scale: 1, opacity: 1 }}
+      transition={{ duration: ASSEMBLE_DUR * T, ease: ASSEMBLE_EASE }}
+      style={{ transformOrigin: '247.95px 223.4px', transformBox: 'fill-box' as const }}
+    >
+      <polygon fill={fill} points={points} />
+    </motion.g>
+  )
+}
+
+function HeroIn({
+  children,
+  delayIndex,
+  fromX,
+  T,
+}: {
+  children: React.ReactNode
+  delayIndex: number
+  fromX: number
+  T: number
+}) {
+  return (
+    <motion.div
+      initial={{ x: fromX, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      transition={{
+        duration: 0.7 * T,
+        delay: (HERO_DELAY + delayIndex * HERO_STAGGER) * T,
+        ease: ASSEMBLE_EASE,
+      }}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/dashboard/frontend/src/pages/PortfolioNexon2026/shared/SlideDeck.tsx
+++ b/dashboard/frontend/src/pages/PortfolioNexon2026/shared/SlideDeck.tsx
@@ -18,7 +18,7 @@ export interface Slide {
   substeps?: number
 }
 
-export default function SlideDeck({ slides, accent = ACCENT }: { slides: Slide[]; accent?: string }) {
+export default function SlideDeck({ slides, accent = ACCENT, onIndexChange }: { slides: Slide[]; accent?: string; onIndexChange?: (i: number) => void }) {
   const [index, setIndex] = useState(0)
   const [subProgress, setSubProgress] = useState(0)
   const lock = useRef(false)
@@ -26,6 +26,9 @@ export default function SlideDeck({ slides, accent = ACCENT }: { slides: Slide[]
   const scrollerRef = useRef<HTMLDivElement>(null)
   const lastDir = useRef(1)
   const total = slides.length
+
+  // 슬라이드 전환을 외부에 알림 — 캐릭터 말풍선 등 섹션 연동용
+  useEffect(() => { onIndexChange?.(index) }, [index, onIndexChange])
 
   useEffect(() => {
     const el = scrollerRef.current


### PR DESCRIPTION
## Summary
- 넥슨 포트폴리오 페이지에 프론트엔드 챕터(덱/스크롤 버전) 추가
- `/portfolio/nexon` 진입 시 프론트엔드 챕터로 리다이렉트

## Test plan
- [ ] `/portfolio/nexon/frontend` 라우트 렌더 확인
- [ ] `/portfolio/nexon/frontend-scroll` 라우트 렌더 확인

(PR 연습용)